### PR TITLE
Follow-up: ServerReadyAction extensibility + extension behavior

### DIFF
--- a/extension/src/debugger/languages/dotnet.ts
+++ b/extension/src/debugger/languages/dotnet.ts
@@ -88,7 +88,7 @@ class DotNetService implements IDotNetService {
                 extensionLogOutputChannel.info(`Executing build task: ${modifiedTask.name} for project: ${projectFile}`);
                 await vscode.tasks.executeTask(modifiedTask);
 
-                let disposable: vscode.Disposable = { dispose: () => {} };
+                let disposable: vscode.Disposable = { dispose: () => { } };
                 return new Promise<void>((resolve, reject) => {
                     disposable = vscode.tasks.onDidEndTaskProcess(async e => {
                         if (e.execution.task === modifiedTask) {
@@ -291,7 +291,7 @@ export function createProjectDebuggerExtension(dotNetServiceProducer: (debugSess
 
             // The apphost's application URL is the Aspire dashboard URL. We already get the dashboard login URL later on,
             // so we should just avoid setting up serverReadyAction and manually open the browser ourselves.
-            if (!launchOptions.isApphost) {
+            if (!launchOptions.isApphost && !debugConfiguration.serverReadyAction) {
                 debugConfiguration.serverReadyAction = determineServerReadyAction(baseProfile?.launchBrowser, baseProfile?.applicationUrl);
             }
 

--- a/extension/src/debugger/launchProfiles.ts
+++ b/extension/src/debugger/launchProfiles.ts
@@ -214,26 +214,26 @@ export function determineWorkingDirectory(
 // https://github.com/microsoft/vscode/blob/2efcdb92310b5ce12636ad6896080476dc42bf1c/extensions/debug-server-ready/package.json
 type ServerReadyAction =
     | {
-        action: 'openExternally';
+        action: "openExternally";
         pattern: string;
         uriFormat: string;
         killOnServerStop?: boolean;
     }
     | {
-        action: 'debugWithChrome' | 'debugWithEdge';
+        action: "debugWithChrome" | "debugWithEdge";
         pattern: string;
         uriFormat: string;
         webRoot: string;
         killOnServerStop?: boolean;
     }
     | {
-        action: 'startDebugging';
+        action: "startDebugging";
         pattern: string;
         name: string;
         killOnServerStop?: boolean;
     }
     | {
-        action: 'startDebugging';
+        action: "startDebugging";
         pattern: string;
         config: Record<string, unknown>;
         killOnServerStop?: boolean;
@@ -247,7 +247,7 @@ export function determineServerReadyAction(launchBrowser?: boolean, applicationU
     let uriFormat = applicationUrl.includes(';') ? applicationUrl.split(';')[0] : applicationUrl;
 
     return {
-        action: 'openExternally',
+        action: "openExternally",
         pattern: "\\bNow listening on:\\s+https?://\\S+",
         uriFormat: uriFormat
     };

--- a/extension/src/debugger/launchProfiles.ts
+++ b/extension/src/debugger/launchProfiles.ts
@@ -176,14 +176,28 @@ export function determineWorkingDirectory(
     projectPath: string,
     baseProfile: LaunchProfile | null
 ): string {
+    const normalizeToPosixPath = (value: string): string => {
+        // VS Code debug configurations accept forward slashes across platforms.
+        // Use path.posix.normalize so we produce stable, slash-normalized paths regardless of host OS.
+        return path.posix.normalize(value.replace(/\\/g, '/'));
+    };
+
     if (baseProfile?.workingDirectory) {
+        const isAbsoluteWorkingDirectory = path.isAbsolute(baseProfile.workingDirectory) || path.win32.isAbsolute(baseProfile.workingDirectory);
+        const isWindowsProjectPath = path.win32.isAbsolute(projectPath);
+
         // If working directory is relative, resolve it relative to project directory
-        if (path.isAbsolute(baseProfile.workingDirectory)) {
+        if (isAbsoluteWorkingDirectory) {
             extensionLogOutputChannel.debug(`Using absolute working directory from launch profile: ${baseProfile.workingDirectory}`);
-            return baseProfile.workingDirectory;
+            return normalizeToPosixPath(baseProfile.workingDirectory);
         } else {
-            const projectDir = path.dirname(projectPath);
-            const workingDir = path.resolve(projectDir, baseProfile.workingDirectory);
+            const projectDir = isWindowsProjectPath ? path.win32.dirname(projectPath) : path.dirname(projectPath);
+
+            let workingDir = isWindowsProjectPath
+                ? path.win32.resolve(projectDir, baseProfile.workingDirectory)
+                : path.resolve(projectDir, baseProfile.workingDirectory);
+
+            workingDir = normalizeToPosixPath(workingDir);
             extensionLogOutputChannel.debug(`Using relative working directory from launch profile: ${workingDir}`);
             return workingDir;
         }
@@ -191,15 +205,39 @@ export function determineWorkingDirectory(
 
     // Default to project directory
     const projectDir = path.dirname(projectPath);
-    extensionLogOutputChannel.debug(`Using default working directory (project directory): ${projectDir}`);
-    return projectDir;
+    const normalizedProjectDir = normalizeToPosixPath(projectDir);
+    extensionLogOutputChannel.debug(`Using default working directory (project directory): ${normalizedProjectDir}`);
+    return normalizedProjectDir;
 }
 
-interface ServerReadyAction {
-    action: "openExternally";
-    pattern: "\\bNow listening on:\\s+https?://\\S+";
-    uriFormat: string;
-}
+// Matches the schema from VS Code's debug-server-ready extension.
+// https://github.com/microsoft/vscode/blob/2efcdb92310b5ce12636ad6896080476dc42bf1c/extensions/debug-server-ready/package.json
+type ServerReadyAction =
+    | {
+        action: 'openExternally';
+        pattern: string;
+        uriFormat: string;
+        killOnServerStop?: boolean;
+    }
+    | {
+        action: 'debugWithChrome' | 'debugWithEdge';
+        pattern: string;
+        uriFormat: string;
+        webRoot: string;
+        killOnServerStop?: boolean;
+    }
+    | {
+        action: 'startDebugging';
+        pattern: string;
+        name: string;
+        killOnServerStop?: boolean;
+    }
+    | {
+        action: 'startDebugging';
+        pattern: string;
+        config: Record<string, unknown>;
+        killOnServerStop?: boolean;
+    };
 
 export function determineServerReadyAction(launchBrowser?: boolean, applicationUrl?: string): ServerReadyAction | undefined {
     if (!launchBrowser || !applicationUrl) {
@@ -209,7 +247,7 @@ export function determineServerReadyAction(launchBrowser?: boolean, applicationU
     let uriFormat = applicationUrl.includes(';') ? applicationUrl.split(';')[0] : applicationUrl;
 
     return {
-        action: "openExternally",
+        action: 'openExternally',
         pattern: "\\bNow listening on:\\s+https?://\\S+",
         uriFormat: uriFormat
     };

--- a/tests/Aspire.Hosting.Tests/ServerReadyActionSerializationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ServerReadyActionSerializationTests.cs
@@ -1,0 +1,142 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Tests;
+
+public class ServerReadyActionSerializationTests
+{
+    [Fact]
+    public void ServerReadyAction_Serializes_ExpectedJsonShape()
+    {
+        // This test guards the public JSON contract we emit for VS Code, including:
+        // - stable property names (action/pattern/uriFormat/webRoot/name/config/killOnServerStop)
+        // - action being serialized as the correct string literal, not as an enum name or numeric value.
+        var config = new System.Text.Json.Nodes.JsonObject
+        {
+            ["type"] = "pwa-chrome",
+            ["request"] = "launch",
+            ["port"] = 1234,
+            ["nested"] = new System.Text.Json.Nodes.JsonObject
+            {
+                ["enabled"] = true
+            }
+        };
+
+        var props = new TestDebuggerProperties
+        {
+            Type = "coreclr",
+            Name = "My Debug Config",
+            WorkingDirectory = "/work",
+            ServerReadyAction = new ServerReadyAction
+            {
+                Action = ServerReadyActionAction.StartDebugging,
+                Pattern = "\\bNow listening on: (https?://\\S+)",
+                UriFormat = "%s",
+                WebRoot = "/client",
+                Name = "FollowUp",
+                Config = config,
+                KillOnServerStop = true,
+            }
+        };
+
+        var json = System.Text.Json.JsonSerializer.Serialize(props);
+
+        using var doc = System.Text.Json.JsonDocument.Parse(json);
+
+        // Ensure we serialize the base debugger properties using the VS Code schema.
+        Assert.Equal("coreclr", doc.RootElement.GetProperty("type").GetString());
+        Assert.Equal("My Debug Config", doc.RootElement.GetProperty("name").GetString());
+        Assert.Equal("/work", doc.RootElement.GetProperty("cwd").GetString());
+
+        var serverReadyAction = doc.RootElement.GetProperty("serverReadyAction");
+
+        Assert.Equal("startDebugging", serverReadyAction.GetProperty("action").GetString());
+        Assert.Equal("\\bNow listening on: (https?://\\S+)", serverReadyAction.GetProperty("pattern").GetString());
+        Assert.Equal("%s", serverReadyAction.GetProperty("uriFormat").GetString());
+        Assert.Equal("/client", serverReadyAction.GetProperty("webRoot").GetString());
+        Assert.Equal("FollowUp", serverReadyAction.GetProperty("name").GetString());
+        Assert.True(serverReadyAction.GetProperty("killOnServerStop").GetBoolean());
+
+        var configElement = serverReadyAction.GetProperty("config");
+        Assert.Equal("pwa-chrome", configElement.GetProperty("type").GetString());
+        Assert.Equal("launch", configElement.GetProperty("request").GetString());
+        Assert.Equal(1234, configElement.GetProperty("port").GetInt32());
+        Assert.True(configElement.GetProperty("nested").GetProperty("enabled").GetBoolean());
+    }
+
+    [Fact]
+    public void ServerReadyAction_RoundTrips_KnownActionAndConfig()
+    {
+        // This test ensures we can deserialize the JSON we emit back into the model.
+        // It specifically covers the new ServerReadyActionAction wrapper and JsonObject config payload.
+        var json = """
+        {
+            "type": "coreclr",
+            "request": "launch",
+            "name": "My Debug Config",
+            "cwd": "/work",
+            "serverReadyAction": {
+                "action": "startDebugging",
+                "pattern": "listening on port ([0-9]+)",
+                "name": "FollowUp",
+                "config": { "foo": "bar" },
+                "killOnServerStop": true
+            }
+        }
+        """;
+
+        var roundtripped = System.Text.Json.JsonSerializer.Deserialize<TestDebuggerProperties>(json);
+
+        Assert.NotNull(roundtripped);
+        Assert.NotNull(roundtripped.ServerReadyAction);
+
+        Assert.Equal(ServerReadyActionAction.StartDebugging, roundtripped.ServerReadyAction.Action);
+        Assert.Equal("listening on port ([0-9]+)", roundtripped.ServerReadyAction.Pattern);
+        Assert.Equal("FollowUp", roundtripped.ServerReadyAction.Name);
+        Assert.True(roundtripped.ServerReadyAction.KillOnServerStop);
+
+        Assert.NotNull(roundtripped.ServerReadyAction.Config);
+        Assert.Equal("bar", roundtripped.ServerReadyAction.Config["foo"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void ServerReadyAction_Allows_UnknownActionStrings()
+    {
+        // VS Code and debug adapters may introduce new action strings over time.
+        // This test ensures we don't fail deserialization when encountering an unrecognized value.
+        var json = """
+        {
+            "type": "coreclr",
+            "request": "launch",
+            "name": "My Debug Config",
+            "cwd": "/work",
+            "serverReadyAction": {
+                "action": "someFutureAction",
+                "pattern": "listening on port ([0-9]+)",
+                "killOnServerStop": false
+            }
+        }
+        """;
+
+        var roundtripped = System.Text.Json.JsonSerializer.Deserialize<TestDebuggerProperties>(json);
+
+        Assert.NotNull(roundtripped);
+        Assert.NotNull(roundtripped.ServerReadyAction);
+        Assert.NotNull(roundtripped.ServerReadyAction.Action);
+        Assert.Equal("someFutureAction", roundtripped.ServerReadyAction.Action.Value.Value);
+
+        Assert.False(roundtripped.ServerReadyAction.Action.Value.TryGetKind(out _));
+    }
+
+    private sealed class TestDebuggerProperties : VSCodeDebuggerProperties
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("type")]
+        public override required string Type { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("name")]
+        public override required string Name { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("cwd")]
+        public override required string WorkingDirectory { get; init; }
+    }
+}


### PR DESCRIPTION
Follow-up contribution for dotnet/aspire#12711. Adds ServerReadyActionAction (discoverable known values + arbitrary strings), preserves existing serverReadyAction in the extension, normalizes cwd paths, and adds C#/TS tests.