### PR TITLE
Re-implement JavaScript and browser debugging support (replaces reverted #14686)

### DIFF
--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -434,7 +434,7 @@
       <source xml:lang="en">Welcome to Aspire</source>
     </trans-unit>
     <trans-unit id="configuration.aspire.registerMcpServerInWorkspace">
-      <source xml:lang="en">Whether to the Aspire MCP server when a workspace is open.</source>
+      <source xml:lang="en">Whether to register the Aspire MCP server when a workspace is open.</source>
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.yesLabel">
       <source xml:lang="en">Yes</source>

--- a/extension/src/capabilities.ts
+++ b/extension/src/capabilities.ts
@@ -12,7 +12,8 @@ export type Capability =
     | 'project' // Support for running C# projects
     | 'ms-dotnettools.csharp' // Older AppHost versions used this extension identifier instead of project
     | 'python' // Support for running Python projects
-    | 'ms-python.python'; // Older AppHost versions used this extension identifier instead of python
+    | 'ms-python.python' // Older AppHost versions used this extension identifier instead of python
+    | 'node'; // Support for running Node.js projects
 
 export type Capabilities = Capability[];
 
@@ -33,6 +34,11 @@ export function isPythonInstalled() {
     return isExtensionInstalled("ms-python.python");
 }
 
+export function isNodeInstalled() {
+    // Node.js debugging uses VS Code's built-in js-debug, no extension needed
+    return true;
+}
+
 export function getSupportedCapabilities(): Capabilities {
     const capabilities: Capabilities = ['prompting', 'baseline.v1', 'secret-prompts.v1', 'file-pickers.v1', 'build-dotnet-using-cli'];
 
@@ -50,6 +56,8 @@ export function getSupportedCapabilities(): Capabilities {
         capabilities.push("python");
         capabilities.push("ms-python.python");
     }
+
+    capabilities.push("node");
 
     return capabilities;
 }

--- a/extension/src/capabilities.ts
+++ b/extension/src/capabilities.ts
@@ -13,7 +13,8 @@ export type Capability =
     | 'ms-dotnettools.csharp' // Older AppHost versions used this extension identifier instead of project
     | 'python' // Support for running Python projects
     | 'ms-python.python' // Older AppHost versions used this extension identifier instead of python
-    | 'node'; // Support for running Node.js projects
+    | 'node' // Support for running Node.js projects
+    | 'browser'; // Support for browser debugging (built-in to VS Code via js-debug)
 
 export type Capabilities = Capability[];
 
@@ -40,7 +41,8 @@ export function isNodeInstalled() {
 }
 
 export function getSupportedCapabilities(): Capabilities {
-    const capabilities: Capabilities = ['prompting', 'baseline.v1', 'secret-prompts.v1', 'file-pickers.v1', 'build-dotnet-using-cli'];
+    // Node.js and browser debugging are built into VS Code via ms-vscode.js-debug, so always available
+    const capabilities: Capabilities = ['prompting', 'baseline.v1', 'secret-prompts.v1', 'file-pickers.v1', 'build-dotnet-using-cli', 'node', 'browser'];
 
     if (isCsDevKitInstalled()) {
         capabilities.push("devkit");
@@ -56,8 +58,6 @@ export function getSupportedCapabilities(): Capabilities {
         capabilities.push("python");
         capabilities.push("ms-python.python");
     }
-
-    capabilities.push("node");
 
     return capabilities;
 }

--- a/extension/src/dcp/types.ts
+++ b/extension/src/dcp/types.ts
@@ -48,6 +48,7 @@ export interface NodeLaunchConfiguration extends ExecutableLaunchConfiguration {
     type: "node";
     script_path?: string;
     runtime_executable?: string;
+    working_directory?: string;
 }
 
 export function isNodeLaunchConfiguration(obj: any): obj is NodeLaunchConfiguration {

--- a/extension/src/dcp/types.ts
+++ b/extension/src/dcp/types.ts
@@ -44,6 +44,16 @@ export function isPythonLaunchConfiguration(obj: any): obj is PythonLaunchConfig
     return obj && obj.type === 'python';
 }
 
+export interface NodeLaunchConfiguration extends ExecutableLaunchConfiguration {
+    type: "node";
+    script_path?: string;
+    runtime_executable?: string;
+}
+
+export function isNodeLaunchConfiguration(obj: any): obj is NodeLaunchConfiguration {
+    return obj && obj.type === 'node';
+}
+
 export interface EnvVar {
     name: string;
     value: string;

--- a/extension/src/dcp/types.ts
+++ b/extension/src/dcp/types.ts
@@ -54,6 +54,17 @@ export function isNodeLaunchConfiguration(obj: any): obj is NodeLaunchConfigurat
     return obj && obj.type === 'node';
 }
 
+export interface BrowserLaunchConfiguration extends ExecutableLaunchConfiguration {
+    type: "browser";
+    url?: string;
+    web_root?: string;
+    browser?: string;
+}
+
+export function isBrowserLaunchConfiguration(obj: any): obj is BrowserLaunchConfiguration {
+    return obj && obj.type === 'browser';
+}
+
 export interface EnvVar {
     name: string;
     value: string;

--- a/extension/src/debugger/debuggerExtensions.ts
+++ b/extension/src/debugger/debuggerExtensions.ts
@@ -4,9 +4,10 @@ import { debugProject, runProject } from "../loc/strings";
 import { mergeEnvs } from "../utils/environment";
 import { extensionLogOutputChannel } from "../utils/logging";
 import { projectDebuggerExtension } from "./languages/dotnet";
-import { isCsharpInstalled, isPythonInstalled, isNodeInstalled } from "../capabilities";
+import { isCsharpInstalled, isPythonInstalled } from "../capabilities";
 import { pythonDebuggerExtension } from "./languages/python";
 import { nodeDebuggerExtension } from "./languages/node";
+import { browserDebuggerExtension } from "./languages/browser";
 import { isDirectory } from "../utils/io";
 
 // Represents a resource-specific debugger extension for when the default session configuration is not sufficient to launch the resource.
@@ -74,6 +75,7 @@ export function getResourceDebuggerExtensions(): ResourceDebuggerExtension[] {
     }
 
     extensions.push(nodeDebuggerExtension);
+    extensions.push(browserDebuggerExtension);
 
     return extensions;
 }

--- a/extension/src/debugger/debuggerExtensions.ts
+++ b/extension/src/debugger/debuggerExtensions.ts
@@ -4,8 +4,9 @@ import { debugProject, runProject } from "../loc/strings";
 import { mergeEnvs } from "../utils/environment";
 import { extensionLogOutputChannel } from "../utils/logging";
 import { projectDebuggerExtension } from "./languages/dotnet";
-import { isCsharpInstalled, isPythonInstalled } from "../capabilities";
+import { isCsharpInstalled, isPythonInstalled, isNodeInstalled } from "../capabilities";
 import { pythonDebuggerExtension } from "./languages/python";
+import { nodeDebuggerExtension } from "./languages/node";
 import { isDirectory } from "../utils/io";
 
 // Represents a resource-specific debugger extension for when the default session configuration is not sufficient to launch the resource.
@@ -71,6 +72,8 @@ export function getResourceDebuggerExtensions(): ResourceDebuggerExtension[] {
     if (isPythonInstalled()) {
         extensions.push(pythonDebuggerExtension);
     }
+
+    extensions.push(nodeDebuggerExtension);
 
     return extensions;
 }

--- a/extension/src/debugger/languages/browser.ts
+++ b/extension/src/debugger/languages/browser.ts
@@ -1,0 +1,38 @@
+import { AspireResourceExtendedDebugConfiguration, ExecutableLaunchConfiguration, isBrowserLaunchConfiguration } from "../../dcp/types";
+import { invalidLaunchConfiguration } from "../../loc/strings";
+import { extensionLogOutputChannel } from "../../utils/logging";
+import { ResourceDebuggerExtension } from "../debuggerExtensions";
+
+export const browserDebuggerExtension: ResourceDebuggerExtension = {
+    resourceType: 'browser',
+    debugAdapter: 'pwa-msedge',
+    extensionId: null, // built-in to VS Code via js-debug
+    getDisplayName: (launchConfiguration: ExecutableLaunchConfiguration) => {
+        if (isBrowserLaunchConfiguration(launchConfiguration) && launchConfiguration.url) {
+            return `Browser: ${launchConfiguration.url}`;
+        }
+        return 'Browser';
+    },
+    getSupportedFileTypes: () => [],
+    getProjectFile: () => '',
+    createDebugSessionConfigurationCallback: async (launchConfig, _args, _env, _launchOptions, debugConfiguration: AspireResourceExtendedDebugConfiguration): Promise<void> => {
+        if (!isBrowserLaunchConfiguration(launchConfig)) {
+            extensionLogOutputChannel.info(`The resource type was not browser for ${JSON.stringify(launchConfig)}`);
+            throw new Error(invalidLaunchConfiguration(JSON.stringify(launchConfig)));
+        }
+
+        debugConfiguration.type = launchConfig.browser || 'msedge';
+        debugConfiguration.request = 'launch';
+        debugConfiguration.url = launchConfig.url;
+        debugConfiguration.webRoot = launchConfig.web_root;
+        debugConfiguration.sourceMaps = true;
+        debugConfiguration.resolveSourceMapLocations = ['**', '!**/node_modules/**'];
+        // Use an auto-managed temp user data directory so multiple browser debuggers
+        // can run concurrently without conflicting
+        debugConfiguration.userDataDir = true;
+
+        // Remove program/args/cwd since browser debugging doesn't use them
+        delete debugConfiguration.program;
+        delete debugConfiguration.args;
+    }
+};

--- a/extension/src/debugger/languages/node.ts
+++ b/extension/src/debugger/languages/node.ts
@@ -1,0 +1,45 @@
+import { AspireResourceExtendedDebugConfiguration, ExecutableLaunchConfiguration, isNodeLaunchConfiguration } from "../../dcp/types";
+import { invalidLaunchConfiguration } from "../../loc/strings";
+import { extensionLogOutputChannel } from "../../utils/logging";
+import { ResourceDebuggerExtension } from "../debuggerExtensions";
+import * as vscode from 'vscode';
+
+function getProjectFile(launchConfig: ExecutableLaunchConfiguration): string {
+    if (isNodeLaunchConfiguration(launchConfig)) {
+        if (launchConfig.script_path) {
+            return launchConfig.script_path;
+        }
+    }
+
+    throw new Error(invalidLaunchConfiguration(JSON.stringify(launchConfig)));
+}
+
+export const nodeDebuggerExtension: ResourceDebuggerExtension = {
+    resourceType: 'node',
+    debugAdapter: 'node',
+    extensionId: null,
+    getDisplayName: (launchConfiguration: ExecutableLaunchConfiguration) => `Node.js: ${vscode.workspace.asRelativePath(getProjectFile(launchConfiguration))}`,
+    getSupportedFileTypes: () => ['.js', '.ts', '.mjs', '.mts', '.cjs', '.cts'],
+    getProjectFile: (launchConfig) => getProjectFile(launchConfig),
+    createDebugSessionConfigurationCallback: async (launchConfig, args, env, launchOptions, debugConfiguration: AspireResourceExtendedDebugConfiguration): Promise<void> => {
+        if (!isNodeLaunchConfiguration(launchConfig)) {
+            extensionLogOutputChannel.info(`The resource type was not node for ${JSON.stringify(launchConfig)}`);
+            throw new Error(invalidLaunchConfiguration(JSON.stringify(launchConfig)));
+        }
+
+        debugConfiguration.type = 'node';
+
+        if (launchConfig.runtime_executable) {
+            debugConfiguration.runtimeExecutable = launchConfig.runtime_executable;
+        }
+
+        // For package manager script execution (e.g., npm run dev), configure runtimeArgs
+        if (launchConfig.runtime_executable && launchConfig.runtime_executable !== 'node') {
+            debugConfiguration.runtimeArgs = ['run', ...(args ?? [])];
+            delete debugConfiguration.args;
+            delete debugConfiguration.program;
+        }
+
+        debugConfiguration.resolveSourceMapLocations = ['**', '!**/node_modules/**'];
+    }
+};

--- a/extension/src/debugger/languages/node.ts
+++ b/extension/src/debugger/languages/node.ts
@@ -6,9 +6,7 @@ import * as vscode from 'vscode';
 
 function getProjectFile(launchConfig: ExecutableLaunchConfiguration): string {
     if (isNodeLaunchConfiguration(launchConfig)) {
-        if (launchConfig.script_path) {
-            return launchConfig.script_path;
-        }
+        return launchConfig.script_path || '';
     }
 
     throw new Error(invalidLaunchConfiguration(JSON.stringify(launchConfig)));
@@ -33,9 +31,10 @@ export const nodeDebuggerExtension: ResourceDebuggerExtension = {
             debugConfiguration.runtimeExecutable = launchConfig.runtime_executable;
         }
 
-        // For package manager script execution (e.g., npm run dev), configure runtimeArgs
+        // For package manager script execution (e.g., npm run dev), use args directly as runtimeArgs.
+        // The args from DCP already contain the full command (e.g., ["run", "dev", "--port", "5173"]).
         if (launchConfig.runtime_executable && launchConfig.runtime_executable !== 'node') {
-            debugConfiguration.runtimeArgs = ['run', ...(args ?? [])];
+            debugConfiguration.runtimeArgs = args ?? [];
             delete debugConfiguration.args;
             delete debugConfiguration.program;
         }

--- a/extension/src/debugger/languages/node.ts
+++ b/extension/src/debugger/languages/node.ts
@@ -6,7 +6,9 @@ import * as vscode from 'vscode';
 
 function getProjectFile(launchConfig: ExecutableLaunchConfiguration): string {
     if (isNodeLaunchConfiguration(launchConfig)) {
-        return launchConfig.script_path || '';
+        // Use the absolute script path if available, otherwise fall back to working directory.
+        // The working directory ensures cwd is set correctly for package manager mode (npm run dev).
+        return launchConfig.script_path || launchConfig.working_directory || '';
     }
 
     throw new Error(invalidLaunchConfiguration(JSON.stringify(launchConfig)));
@@ -16,16 +18,27 @@ export const nodeDebuggerExtension: ResourceDebuggerExtension = {
     resourceType: 'node',
     debugAdapter: 'node',
     extensionId: null,
-    getDisplayName: (launchConfiguration: ExecutableLaunchConfiguration) => `Node.js: ${vscode.workspace.asRelativePath(getProjectFile(launchConfiguration))}`,
+    getDisplayName: (launchConfiguration: ExecutableLaunchConfiguration) => {
+        if (isNodeLaunchConfiguration(launchConfiguration)) {
+            const displayPath = launchConfiguration.script_path || launchConfiguration.working_directory || '';
+            return `Node.js: ${displayPath ? vscode.workspace.asRelativePath(displayPath) : 'unknown'}`;
+        }
+        return 'Node.js';
+    },
     getSupportedFileTypes: () => ['.js', '.ts', '.mjs', '.mts', '.cjs', '.cts'],
     getProjectFile: (launchConfig) => getProjectFile(launchConfig),
-    createDebugSessionConfigurationCallback: async (launchConfig, args, env, launchOptions, debugConfiguration: AspireResourceExtendedDebugConfiguration): Promise<void> => {
+    createDebugSessionConfigurationCallback: async (launchConfig, args, _env, _launchOptions, debugConfiguration: AspireResourceExtendedDebugConfiguration): Promise<void> => {
         if (!isNodeLaunchConfiguration(launchConfig)) {
             extensionLogOutputChannel.info(`The resource type was not node for ${JSON.stringify(launchConfig)}`);
             throw new Error(invalidLaunchConfiguration(JSON.stringify(launchConfig)));
         }
 
         debugConfiguration.type = 'node';
+
+        // Use working_directory for cwd if available
+        if (launchConfig.working_directory) {
+            debugConfiguration.cwd = launchConfig.working_directory;
+        }
 
         if (launchConfig.runtime_executable) {
             debugConfiguration.runtimeExecutable = launchConfig.runtime_executable;

--- a/playground/AspireWithJavaScript/.vscode/settings.json
+++ b/playground/AspireWithJavaScript/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "aspire.dashboardBrowser": "simpleBrowser"
+}

--- a/playground/AspireWithJavaScript/AspireJavaScript.AppHost/AppHost.cs
+++ b/playground/AspireWithJavaScript/AspireJavaScript.AppHost/AppHost.cs
@@ -10,13 +10,16 @@ builder.AddJavaScriptApp("angular", "../AspireJavaScript.Angular", runScriptName
     .WithExternalHttpEndpoints()
     .PublishAsDockerFile();
 
+#pragma warning disable ASPIREEXTENSION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 builder.AddJavaScriptApp("react", "../AspireJavaScript.React", runScriptName: "start")
     .WithReference(weatherApi)
     .WaitFor(weatherApi)
     .WithEnvironment("BROWSER", "none") // Disable opening browser on npm start
     .WithHttpEndpoint(env: "PORT")
     .WithExternalHttpEndpoints()
-    .PublishAsDockerFile();
+    .PublishAsDockerFile()
+    .WithBrowserDebugger();
+#pragma warning restore ASPIREEXTENSION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 builder.AddJavaScriptApp("vue", "../AspireJavaScript.Vue")
     .WithRunScript("start")
@@ -27,10 +30,12 @@ builder.AddJavaScriptApp("vue", "../AspireJavaScript.Vue")
     .WithExternalHttpEndpoints()
     .PublishAsDockerFile();
 
+#pragma warning disable ASPIREEXTENSION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 var reactvite = builder.AddViteApp("reactvite", "../AspireJavaScript.Vite")
     .WithReference(weatherApi)
     .WithEnvironment("BROWSER", "none")
     .WithExternalHttpEndpoints();
+#pragma warning restore ASPIREEXTENSION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 builder.AddNodeApp("node", "../AspireJavaScript.NodeApp", "app.js")
     .WithRunScript("dev") // Use 'npm run dev' for development

--- a/playground/AspireWithJavaScript/AspireJavaScript.MinimalApi/AppHost.cs
+++ b/playground/AspireWithJavaScript/AspireJavaScript.MinimalApi/AppHost.cs
@@ -5,19 +5,11 @@ builder.AddServiceDefaults();
 // Add services to the container.
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
 builder.Services.AddCors();
 
 var app = builder.Build();
 
 app.MapDefaultEndpoints();
-
-// Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
 
 app.UseHttpsRedirection();
 app.UseCors(static builder =>
@@ -42,8 +34,7 @@ app.MapGet("/api/weatherforecast", () =>
         .ToArray();
     return forecast;
 })
-.WithName("GetWeatherForecast")
-.WithOpenApi();
+.WithName("GetWeatherForecast");
 
 app.UseFileServer();
 

--- a/playground/AspireWithJavaScript/AspireJavaScript.MinimalApi/Properties/launchSettings.json
+++ b/playground/AspireWithJavaScript/AspireJavaScript.MinimalApi/Properties/launchSettings.json
@@ -13,7 +13,6 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "swagger",
       "applicationUrl": "http://localhost:5084",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -23,7 +22,6 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "swagger",
       "applicationUrl": "https://localhost:7167;http://localhost:5084",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/playground/AspireWithJavaScript/AspireJavaScript.NodeApp/app.js
+++ b/playground/AspireWithJavaScript/AspireJavaScript.NodeApp/app.js
@@ -69,7 +69,7 @@ app.use((err, req, res, next) => {
 });
 
 // General 404 handler (for non-API routes)
-app.use('*', (req, res) => {
+app.use((req, res) => {
     res.status(404).json({
         message: 'Route not found',
         path: req.originalUrl

--- a/playground/AspireWithJavaScript/AspireJavaScript.React/webpack.config.js
+++ b/playground/AspireWithJavaScript/AspireJavaScript.React/webpack.config.js
@@ -3,6 +3,7 @@ const HTMLWebpackPlugin = require("html-webpack-plugin");
 module.exports = (env) => {
   return {
     entry: "./src/index.js",
+    devtool: "source-map",
     devServer: {
       port: env.PORT || 4001,
       allowedHosts: "all",

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -34,8 +34,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
     private readonly Diagnostics.FileLoggerProvider _fileLoggerProvider;
 
     private static readonly string[] s_detectionPatterns = ["*.csproj", "*.fsproj", "*.vbproj", "apphost.cs"];
-    internal static IReadOnlyCollection<string> ProjectExtensions { get; } =
-        Array.AsReadOnly([".csproj", ".fsproj", ".vbproj"]);
+    private static readonly string[] s_projectExtensions = [".csproj", ".fsproj", ".vbproj"];
 
     public DotNetAppHostProject(
         IDotNetCliRunner runner,
@@ -86,7 +85,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         var extension = appHostFile.Extension.ToLowerInvariant();
 
         // Handle project files (.csproj, .fsproj, .vbproj)
-        if (ProjectExtensions.Contains(extension))
+        if (s_projectExtensions.Contains(extension))
         {
             // We can handle any project file - ValidateAsync will do deeper validation
             return true;
@@ -476,7 +475,6 @@ internal sealed class DotNetAppHostProject : IAppHostProject
             context.PackageId,
             context.PackageVersion,
             context.Source,
-            noRestore: false,
             options,
             cancellationToken);
 
@@ -522,7 +520,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
 
         // Auto-initialize user secrets (only for csproj projects - file-based apphosts
         // always have a UserSecretsId provided by the SDK)
-        if (!ProjectExtensions.Contains(projectFile.Extension.ToLowerInvariant()))
+        if (!s_projectExtensions.Contains(projectFile.Extension.ToLowerInvariant()))
         {
             return userSecretsId;
         }

--- a/src/Aspire.Hosting.JavaScript/Aspire.Hosting.JavaScript.csproj
+++ b/src/Aspire.Hosting.JavaScript/Aspire.Hosting.JavaScript.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedDir)PathNormalizer.cs" Link="Utils\PathNormalizer.cs" />
+    <Compile Include="$(RepoRoot)src\Aspire.Hosting\Dcp\Model\ExecutableLaunchConfiguration.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.JavaScript/Aspire.Hosting.JavaScript.csproj
+++ b/src/Aspire.Hosting.JavaScript/Aspire.Hosting.JavaScript.csproj
@@ -8,12 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="$(SharedDir)PathNormalizer.cs" Link="Utils\PathNormalizer.cs" />
-    <Compile Include="$(RepoRoot)src\Aspire.Hosting\Dcp\Model\ExecutableLaunchConfiguration.cs" />
+    <ProjectReference Include="..\Aspire.Hosting\Aspire.Hosting.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Aspire.Hosting\Aspire.Hosting.csproj" />
+    <InternalsVisibleTo Include="Aspire.Hosting.JavaScript.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/Aspire.Hosting.JavaScript/BrowserDebuggerResource.cs
+++ b/src/Aspire.Hosting.JavaScript/BrowserDebuggerResource.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.JavaScript;
+
+internal sealed class BrowserDebuggerResource(string name, string browser, string workingDirectory)
+    : ExecutableResource(name, browser, workingDirectory)
+{
+}

--- a/src/Aspire.Hosting.JavaScript/BrowserLaunchConfiguration.cs
+++ b/src/Aspire.Hosting.JavaScript/BrowserLaunchConfiguration.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+using Aspire.Hosting.Dcp.Model;
+
+namespace Aspire.Hosting.JavaScript;
+
+internal sealed class BrowserLaunchConfiguration() : ExecutableLaunchConfiguration("browser")
+{
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = string.Empty;
+
+    [JsonPropertyName("web_root")]
+    public string WebRoot { get; set; } = string.Empty;
+
+    [JsonPropertyName("browser")]
+    public string Browser { get; set; } = "msedge";
+}

--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -4,7 +4,9 @@
 #pragma warning disable ASPIREDOCKERFILEBUILDER001
 #pragma warning disable ASPIREPIPELINES001
 #pragma warning disable ASPIRECERTIFICATES001
+#pragma warning disable ASPIREEXTENSION001
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 using Aspire.Hosting.ApplicationModel;
@@ -258,6 +260,8 @@ public static class JavaScriptHostingExtensions
             resourceBuilder.WithNpm();
         }
 
+        resourceBuilder.WithVSCodeDebugging(scriptPath);
+
         if (builder.ExecutionContext.IsRunMode)
         {
             builder.Eventing.Subscribe<BeforeStartEvent>((_, _) =>
@@ -459,6 +463,8 @@ public static class JavaScriptHostingExtensions
             .WithAnnotation(new ContainerFilesSourceAnnotation() { SourcePath = "/app/dist" })
             .WithBuildScript("build")
             .WithRunScript(runScriptName);
+
+        resourceBuilder.WithVSCodeDebugging();
 
         // ensure the package manager command is set before starting the resource
         if (builder.ExecutionContext.IsRunMode)
@@ -933,6 +939,53 @@ public static class JavaScriptHostingExtensions
     public static IResourceBuilder<TResource> WithRunScript<TResource>(this IResourceBuilder<TResource> resource, string scriptName, string[]? args = null) where TResource : JavaScriptAppResource
     {
         return resource.WithAnnotation(new JavaScriptRunScriptAnnotation(scriptName, args));
+    }
+
+    [Experimental("ASPIREEXTENSION001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    internal static IResourceBuilder<T> WithVSCodeDebugging<T>(this IResourceBuilder<T> builder, string scriptPath)
+        where T : NodeAppResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(scriptPath);
+
+        // Check if a run script annotation is present - if so, use package manager instead of direct node
+        var hasRunScript = builder.Resource.TryGetLastAnnotation<JavaScriptRunScriptAnnotation>(out _);
+        var hasPackageManager = builder.Resource.TryGetLastAnnotation<JavaScriptPackageManagerAnnotation>(out var pmAnnotation);
+
+        var runtimeExecutable = hasRunScript && hasPackageManager ? pmAnnotation!.ExecutableName : "node";
+
+        return builder.WithDebugSupport(
+            mode => new NodeLaunchConfiguration
+            {
+                ScriptPath = scriptPath,
+                Mode = mode,
+                RuntimeExecutable = runtimeExecutable
+            },
+            "node");
+    }
+
+    [Experimental("ASPIREEXTENSION001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    internal static IResourceBuilder<T> WithVSCodeDebugging<T>(this IResourceBuilder<T> builder)
+        where T : JavaScriptAppResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        // Get package manager info for runtime executable
+        var packageManager = "npm";
+
+        if (builder.Resource.TryGetLastAnnotation<JavaScriptPackageManagerAnnotation>(out var pmAnnotation))
+        {
+            packageManager = pmAnnotation.ExecutableName;
+        }
+
+        return builder.WithDebugSupport(
+            mode => new NodeLaunchConfiguration
+            {
+                ScriptPath = string.Empty,
+                Mode = mode,
+                RuntimeExecutable = packageManager
+            },
+            "node");
     }
 
     private static void AddInstaller<TResource>(IResourceBuilder<TResource> resource, bool install) where TResource : JavaScriptAppResource

--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -9,6 +9,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.ApplicationModel.Docker;
 using Aspire.Hosting.JavaScript;
@@ -27,6 +28,9 @@ namespace Aspire.Hosting;
 public static class JavaScriptHostingExtensions
 {
     private const string DefaultNodeVersion = "22";
+
+    // This must match the value in Aspire.Cli KnownCapabilities.Browser
+    private const string BrowserCapability = "browser";
 
     // This is the order of config files that Vite will look for by default
     // See https://github.com/vitejs/vite/blob/main/packages/vite/src/node/constants.ts#L97
@@ -986,6 +990,82 @@ public static class JavaScriptHostingExtensions
                 RuntimeExecutable = packageManager
             },
             "node");
+    }
+
+    [Experimental("ASPIREEXTENSION001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    internal static IResourceBuilder<T> WithBrowserDebugger<T>(
+        this IResourceBuilder<T> builder,
+        string browser = "msedge")
+        where T : JavaScriptAppResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        // Validate that the extension supports browser debugging if we're running in an extension context
+        ValidateBrowserCapability(builder);
+
+        var parentResource = builder.Resource;
+        var debuggerResourceName = $"{parentResource.Name}-browser";
+
+        // Find the parent's HTTP/HTTPS endpoint
+        EndpointAnnotation? endpointAnnotation = null;
+        if (parentResource.TryGetAnnotationsOfType<EndpointAnnotation>(out var endpoints))
+        {
+            endpointAnnotation = endpoints.FirstOrDefault(e => e.UriScheme == "https")
+                ?? endpoints.FirstOrDefault(e => e.UriScheme == "http");
+        }
+
+        if (endpointAnnotation is null)
+        {
+            throw new InvalidOperationException(
+                $"Resource '{parentResource.Name}' does not have an HTTP or HTTPS endpoint. Browser debugging requires an endpoint to navigate to.");
+        }
+
+        var endpointReference = parentResource.GetEndpoint(endpointAnnotation.Name);
+
+        var debuggerResource = new BrowserDebuggerResource(debuggerResourceName, browser, parentResource.WorkingDirectory);
+
+        builder.ApplicationBuilder.AddResource(debuggerResource)
+            .WithParentRelationship(parentResource)
+            .WaitFor(builder)
+            .ExcludeFromManifest()
+            .WithDebugSupport(
+                mode => new BrowserLaunchConfiguration
+                {
+                    Mode = mode,
+                    Url = endpointReference.Url,
+                    WebRoot = parentResource.WorkingDirectory,
+                    Browser = browser
+                },
+                BrowserCapability);
+
+        return builder;
+    }
+
+    private static void ValidateBrowserCapability<T>(IResourceBuilder<T> builder) where T : IResource
+    {
+        var configuration = builder.ApplicationBuilder.Configuration;
+
+        try
+        {
+            if (configuration["DEBUG_SESSION_INFO"] is { } debugSessionInfoJson
+                && JsonSerializer.Deserialize<DebugSessionCapabilities>(debugSessionInfoJson) is { } info
+                && info.SupportedLaunchConfigurations is not null
+                && !info.SupportedLaunchConfigurations.Contains(BrowserCapability))
+            {
+                throw new InvalidOperationException(
+                    "This version of the Aspire extension does not support browser debugging. Please update the Aspire extension to use browser debugging support with WithBrowserDebugger().");
+            }
+        }
+        catch (JsonException)
+        {
+            // If we can't parse the debug session info, skip validation
+        }
+    }
+
+    private sealed class DebugSessionCapabilities
+    {
+        [JsonPropertyName("supported_launch_configurations")]
+        public string[]? SupportedLaunchConfigurations { get; set; }
     }
 
     private static void AddInstaller<TResource>(IResourceBuilder<TResource> resource, bool install) where TResource : JavaScriptAppResource

--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -957,13 +957,16 @@ public static class JavaScriptHostingExtensions
         var hasPackageManager = builder.Resource.TryGetLastAnnotation<JavaScriptPackageManagerAnnotation>(out var pmAnnotation);
 
         var runtimeExecutable = hasRunScript && hasPackageManager ? pmAnnotation!.ExecutableName : "node";
+        var workingDirectory = builder.Resource.WorkingDirectory;
+        var absoluteScriptPath = Path.GetFullPath(scriptPath, workingDirectory);
 
         return builder.WithDebugSupport(
-            mode => new NodeLaunchConfiguration
+            options => new NodeLaunchConfiguration
             {
-                ScriptPath = scriptPath,
-                Mode = mode,
-                RuntimeExecutable = runtimeExecutable
+                ScriptPath = absoluteScriptPath,
+                Mode = options.Mode,
+                RuntimeExecutable = runtimeExecutable,
+                WorkingDirectory = workingDirectory
             },
             "node");
     }
@@ -982,18 +985,47 @@ public static class JavaScriptHostingExtensions
             packageManager = pmAnnotation.ExecutableName;
         }
 
+        var workingDirectory = builder.Resource.WorkingDirectory;
+
         return builder.WithDebugSupport(
-            mode => new NodeLaunchConfiguration
+            options => new NodeLaunchConfiguration
             {
                 ScriptPath = string.Empty,
-                Mode = mode,
-                RuntimeExecutable = packageManager
+                Mode = options.Mode,
+                RuntimeExecutable = packageManager,
+                WorkingDirectory = workingDirectory
             },
             "node");
     }
 
+    /// <summary>
+    /// Configures a browser debugger for the JavaScript application resource, enabling browser-based debugging
+    /// through a child resource that launches when the parent application is ready.
+    /// </summary>
+    /// <typeparam name="T">The type of the JavaScript application resource.</typeparam>
+    /// <param name="builder">The resource builder for the JavaScript application.</param>
+    /// <param name="browser">The browser to use for debugging. Defaults to <c>"msedge"</c>. Supported values include <c>"msedge"</c> and <c>"chrome"</c>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining additional configuration.</returns>
+    /// <remarks>
+    /// This method creates a child <see cref="BrowserDebuggerResource"/> that waits for the parent JavaScript
+    /// application to start, then launches a browser debug session targeting the parent's HTTP or HTTPS endpoint.
+    /// The parent resource must have at least one HTTP or HTTPS endpoint configured.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the parent resource does not have an HTTP or HTTPS endpoint, or when the IDE extension
+    /// does not support browser debugging.
+    /// </exception>
+    /// <example>
+    /// Add browser debugging to a JavaScript application:
+    /// <code>
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    /// builder.AddViteApp("frontend", "./frontend")
+    ///     .WithBrowserDebugger();
+    /// </code>
+    /// </example>
     [Experimental("ASPIREEXTENSION001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-    internal static IResourceBuilder<T> WithBrowserDebugger<T>(
+    [AspireExport("withBrowserDebugger", Description = "Configures a browser debugger for the JavaScript application")]
+    public static IResourceBuilder<T> WithBrowserDebugger<T>(
         this IResourceBuilder<T> builder,
         string browser = "msedge")
         where T : JavaScriptAppResource
@@ -1029,9 +1061,9 @@ public static class JavaScriptHostingExtensions
             .WaitFor(builder)
             .ExcludeFromManifest()
             .WithDebugSupport(
-                mode => new BrowserLaunchConfiguration
+                options => new BrowserLaunchConfiguration
                 {
-                    Mode = mode,
+                    Mode = options.Mode,
                     Url = endpointReference.Url,
                     WebRoot = parentResource.WorkingDirectory,
                     Browser = browser

--- a/src/Aspire.Hosting.JavaScript/NodeLaunchConfiguration.cs
+++ b/src/Aspire.Hosting.JavaScript/NodeLaunchConfiguration.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+using Aspire.Hosting.Dcp.Model;
+
+namespace Aspire.Hosting.JavaScript;
+
+internal sealed class NodeLaunchConfiguration() : ExecutableLaunchConfiguration("node")
+{
+    [JsonPropertyName("script_path")]
+    public string ScriptPath { get; set; } = string.Empty;
+
+    [JsonPropertyName("runtime_executable")]
+    public string RuntimeExecutable { get; set; } = string.Empty;
+}

--- a/src/Aspire.Hosting.JavaScript/NodeLaunchConfiguration.cs
+++ b/src/Aspire.Hosting.JavaScript/NodeLaunchConfiguration.cs
@@ -13,4 +13,7 @@ internal sealed class NodeLaunchConfiguration() : ExecutableLaunchConfiguration(
 
     [JsonPropertyName("runtime_executable")]
     public string RuntimeExecutable { get; set; } = string.Empty;
+
+    [JsonPropertyName("working_directory")]
+    public string WorkingDirectory { get; set; } = string.Empty;
 }

--- a/src/Aspire.Hosting.Python/Aspire.Hosting.Python.csproj
+++ b/src/Aspire.Hosting.Python/Aspire.Hosting.Python.csproj
@@ -9,8 +9,6 @@
 
   <ItemGroup>
     <Compile Include="$(SharedDir)PathNormalizer.cs" Link="Utils\PathNormalizer.cs" />
-    <Compile Include="$(SharedDir)OverloadResolutionPriorityAttribute.cs" Link="Utils\OverloadResolutionPriorityAttribute.cs" />
-    <Compile Include="$(RepoRoot)src\Aspire.Hosting\Dcp\Model\ExecutableLaunchConfiguration.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
@@ -944,7 +944,7 @@ public static class PythonAppResourceBuilderExtensions
         }
 
         builder.WithDebugSupport(
-            mode =>
+            options =>
             {
                 string interpreterPath;
                 if (!builder.Resource.TryGetLastAnnotation<PythonEnvironmentAnnotation>(out var annotation) || annotation.VirtualEnvironment is null)
@@ -971,7 +971,7 @@ public static class PythonAppResourceBuilderExtensions
                 {
                     ProgramPath = programPath,
                     Module = module,
-                    Mode = mode,
+                    Mode = options.Mode,
                     InterpreterPath = interpreterPath
                 };
             },

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -113,6 +113,9 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Aspire.Hosting.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Yarp.Tests" />
+    <InternalsVisibleTo Include="Aspire.Hosting.JavaScript" />
+    <InternalsVisibleTo Include="Aspire.Hosting.JavaScript.Tests" />
+    <InternalsVisibleTo Include="Aspire.Hosting.Python" />
     <InternalsVisibleTo Include="Aspire.Hosting.Python.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Testing.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Containers.Tests" />

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1323,11 +1323,12 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             exe.Annotate(CustomResource.OtelServiceInstanceIdAnnotation, exeInstance.Suffix);
             exe.Annotate(CustomResource.ResourceNameAnnotation, executable.Name);
 
-            if (executable.SupportsDebugging(_configuration, out var supportsDebuggingAnnotation))
+            if (executable.SupportsDebugging(_configuration, out _))
             {
+                // Just mark as IDE execution here - the actual launch configuration callback
+                // will be invoked in CreateExecutableAsync after endpoints are allocated.
                 exe.Spec.ExecutionType = ExecutionType.IDE;
                 exe.Spec.FallbackExecutionTypes = [ ExecutionType.Process ];
-                supportsDebuggingAnnotation.LaunchConfigurationAnnotator(exe, _configuration[KnownConfigNames.DebugSessionRunMode] ?? ExecutableLaunchMode.NoDebug);
             }
             else
             {
@@ -1745,6 +1746,28 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             if (configuration.Exception is not null)
             {
                 throw new FailedToApplyEnvironmentException();
+            }
+
+            // Invoke the debug configuration callback now that endpoints are allocated.
+            // This allows launch configurations to access endpoint URLs that were not
+            // available during PrepareExecutables().
+            // Project resources configure their launch configs in PrepareProjectExecutables() directly,
+            // so we only invoke the annotator for non-project executables here.
+            if (er.ModelResource is not ProjectResource
+                && er.ModelResource.SupportsDebugging(_configuration, out var supportsDebuggingAnnotation))
+            {
+                var mode = _configuration[KnownConfigNames.DebugSessionRunMode] ?? ExecutableLaunchMode.NoDebug;
+                try
+                {
+                    // Clear any existing launch configurations (needed for restart scenarios).
+                    exe.Annotate(Executable.LaunchConfigurationsAnnotation, string.Empty);
+                    supportsDebuggingAnnotation.LaunchConfigurationAnnotator(exe, new LaunchConfigurationProducerOptions { Mode = mode });
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to apply launch configuration for resource '{ResourceName}'. Falling back to process execution.", er.ModelResource.Name);
+                    exe.Spec.ExecutionType = ExecutionType.Process;
+                }
             }
 
             await _kubernetesService.CreateAsync(exe, cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Hosting/Dcp/Model/ExecutableLaunchConfiguration.cs
+++ b/src/Aspire.Hosting/Dcp/Model/ExecutableLaunchConfiguration.cs
@@ -30,7 +30,7 @@ internal class ExecutableLaunchConfiguration(string type)
     public string Mode { get; set; } = System.Diagnostics.Debugger.IsAttached ? ExecutableLaunchMode.Debug : ExecutableLaunchMode.NoDebug;
 }
 
-internal class ProjectLaunchConfiguration() : ExecutableLaunchConfiguration("project")
+internal sealed class ProjectLaunchConfiguration() : ExecutableLaunchConfiguration("project")
 {
     [JsonPropertyName("launch_profile")]
     public string LaunchProfile { get; set; } = string.Empty;

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -253,7 +253,7 @@ public static class ProjectResourceBuilderExtensions
         var project = new ProjectResource(name);
         return builder.AddResource(project)
                       .WithAnnotation(projectMetadata)
-                      .WithDebugSupport(mode => new ProjectLaunchConfiguration { ProjectPath = projectMetadata.ProjectPath, Mode = mode }, "project")
+                      .WithDebugSupport(options => new ProjectLaunchConfiguration { ProjectPath = projectMetadata.ProjectPath, Mode = options.Mode }, "project")
                       .WithProjectDefaults(options);
     }
 
@@ -299,7 +299,7 @@ public static class ProjectResourceBuilderExtensions
 
         return builder.AddResource(project)
                       .WithAnnotation(new ProjectMetadata(projectPath))
-                      .WithDebugSupport(mode => new ProjectLaunchConfiguration { ProjectPath = projectPath, Mode = mode }, "project")
+                      .WithDebugSupport(options => new ProjectLaunchConfiguration { ProjectPath = projectPath, Mode = options.Mode }, "project")
                       .WithProjectDefaults(options);
     }
 
@@ -382,7 +382,7 @@ public static class ProjectResourceBuilderExtensions
 
         var resource = builder.AddResource(app)
                               .WithAnnotation(projectMetadata)
-                              .WithDebugSupport(mode => new ProjectLaunchConfiguration { ProjectPath = projectMetadata.ProjectPath, Mode = mode }, "project")
+                              .WithDebugSupport(options => new ProjectLaunchConfiguration { ProjectPath = projectMetadata.ProjectPath, Mode = options.Mode }, "project")
                               .WithProjectDefaults(options);
 
         resource.OnBeforeResourceStarted(async (r, e, ct) =>

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -3158,7 +3158,7 @@ public static class ResourceBuilderExtensions
     /// <param name="launchConfigurationType">The type of the resource.</param>
     /// <param name="argsCallback">Optional callback to add or modify command line arguments when running in an extension host. Useful if the entrypoint is usually provided as an argument to the resource executable.</param>
     [Experimental("ASPIREEXTENSION001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-    public static IResourceBuilder<T> WithDebugSupport<T, TLaunchConfiguration>(this IResourceBuilder<T> builder, Func<string, TLaunchConfiguration> launchConfigurationProducer, string launchConfigurationType, Action<CommandLineArgsCallbackContext>? argsCallback = null)
+    internal static IResourceBuilder<T> WithDebugSupport<T, TLaunchConfiguration>(this IResourceBuilder<T> builder, Func<LaunchConfigurationProducerOptions, TLaunchConfiguration> launchConfigurationProducer, string launchConfigurationType, Action<CommandLineArgsCallbackContext>? argsCallback = null)
         where T : IResource
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting/SupportsDebuggingAnnotation.cs
+++ b/src/Aspire.Hosting/SupportsDebuggingAnnotation.cs
@@ -8,26 +8,38 @@ using Aspire.Hosting.Dcp.Model;
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
+/// Options passed to the launch configuration producer when creating debug launch configurations.
+/// </summary>
+[Experimental("ASPIREEXTENSION001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+internal sealed class LaunchConfigurationProducerOptions
+{
+    /// <summary>
+    /// Gets the debug session run mode.
+    /// </summary>
+    public required string Mode { get; init; }
+}
+
+/// <summary>
 /// Represents an annotation that specifies that the resource can be debugged by the Aspire Extension.
 /// </summary>
 [DebuggerDisplay("Type = {GetType().Name,nq}, RequiredExtensionId = {LaunchConfigurationType,nq}")]
 [Experimental("ASPIREEXTENSION001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 internal sealed class SupportsDebuggingAnnotation : IResourceAnnotation
 {
-    private SupportsDebuggingAnnotation(string launchConfigurationType, Action<Executable, string> launchConfigurationAnnotator)
+    private SupportsDebuggingAnnotation(string launchConfigurationType, Action<Executable, LaunchConfigurationProducerOptions> launchConfigurationAnnotator)
     {
         LaunchConfigurationType = launchConfigurationType;
         LaunchConfigurationAnnotator = launchConfigurationAnnotator;
     }
 
     public string LaunchConfigurationType { get; }
-    public Action<Executable, string> LaunchConfigurationAnnotator { get; }
+    public Action<Executable, LaunchConfigurationProducerOptions> LaunchConfigurationAnnotator { get; }
 
-    internal static SupportsDebuggingAnnotation Create<T>(string launchConfigurationType, Func<string, T> launchProfileProducer)
+    internal static SupportsDebuggingAnnotation Create<T>(string launchConfigurationType, Func<LaunchConfigurationProducerOptions, T> launchProfileProducer)
     {
-        return new SupportsDebuggingAnnotation(launchConfigurationType, (exe, mode) =>
+        return new SupportsDebuggingAnnotation(launchConfigurationType, (exe, options) =>
         {
-            exe.AnnotateAsObjectList(Executable.LaunchConfigurationsAnnotation, launchProfileProducer(mode));
+            exe.AnnotateAsObjectList(Executable.LaunchConfigurationsAnnotation, launchProfileProducer(options));
         });
     }
 }

--- a/tests/Aspire.Hosting.JavaScript.Tests/AddNodeAppTests.cs
+++ b/tests/Aspire.Hosting.JavaScript.Tests/AddNodeAppTests.cs
@@ -107,39 +107,39 @@ public class AddNodeAppTests
         var expectedDockerfile = includePackageJson ?
             """
             FROM node:22-alpine AS build
-            
+
             WORKDIR /app
             COPY package*.json ./
             RUN --mount=type=cache,target=/root/.npm npm ci
             COPY . .
-            
+
             FROM node:22-alpine AS runtime
-            
+
             WORKDIR /app
             COPY --from=build /app /app
-            
+
             ENV NODE_ENV=production
-            
+
             USER node
-            
+
             ENTRYPOINT ["node","app.js"]
 
             """.Replace("\r\n", "\n") :
             """
             FROM node:22-alpine AS build
-            
+
             WORKDIR /app
             COPY . .
-            
+
             FROM node:22-alpine AS runtime
-            
+
             WORKDIR /app
             COPY --from=build /app /app
-            
+
             ENV NODE_ENV=production
-            
+
             USER node
-            
+
             ENTRYPOINT ["node","app.js"]
 
             """.Replace("\r\n", "\n");
@@ -418,4 +418,122 @@ public class AddNodeAppTests
 
     private sealed class MyFilesContainer(string name, string command, string workingDirectory)
         : ExecutableResource(name, command, workingDirectory), IResourceWithContainerFiles;
+
+#pragma warning disable ASPIREEXTENSION001 // Type is for evaluation purposes only
+
+    [Fact]
+    public void NodeApp_WithVSCodeDebugging_AddsSupportsDebuggingAnnotation()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        using var tempDir = new TestTempDirectory();
+
+        var nodeApp = builder.AddNodeApp("nodeapp", tempDir.Path, "app.js");
+
+        var annotation = nodeApp.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().SingleOrDefault();
+        Assert.NotNull(annotation);
+        Assert.Equal("node", annotation.LaunchConfigurationType);
+    }
+
+    [Fact]
+    public void NodeApp_WithVSCodeDebugging_DoesNotAddAnnotationInPublishMode()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        using var tempDir = new TestTempDirectory();
+
+        var nodeApp = builder.AddNodeApp("nodeapp", tempDir.Path, "app.js");
+
+        var annotation = nodeApp.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().SingleOrDefault();
+        Assert.Null(annotation);
+    }
+
+    [Fact]
+    public void ViteApp_WithVSCodeDebugging_AddsSupportsDebuggingAnnotation()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        using var tempDir = new TestTempDirectory();
+
+        var viteApp = builder.AddViteApp("viteapp", tempDir.Path);
+
+        var annotation = viteApp.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().SingleOrDefault();
+        Assert.NotNull(annotation);
+        Assert.Equal("node", annotation.LaunchConfigurationType);
+    }
+
+    [Fact]
+    public void ViteApp_WithBrowserDebugger_CreatesChildResource()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        using var tempDir = new TestTempDirectory();
+
+        var viteApp = builder.AddViteApp("viteapp", tempDir.Path)
+            .WithBrowserDebugger();
+
+        using var app = builder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var browserDebuggerResource = appModel.Resources.OfType<BrowserDebuggerResource>().SingleOrDefault();
+        Assert.NotNull(browserDebuggerResource);
+        Assert.Equal("viteapp-browser", browserDebuggerResource.Name);
+
+        // Verify parent relationship
+        Assert.True(browserDebuggerResource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationships));
+        var parentRelationship = Assert.Single(relationships, r => r.Type == "Parent");
+        Assert.Same(viteApp.Resource, parentRelationship.Resource);
+
+        // Verify supports debugging annotation
+        var annotation = browserDebuggerResource.Annotations.OfType<SupportsDebuggingAnnotation>().SingleOrDefault();
+        Assert.NotNull(annotation);
+        Assert.Equal("browser", annotation.LaunchConfigurationType);
+    }
+
+    [Fact]
+    public void ViteApp_WithBrowserDebugger_DefaultsToEdgeBrowser()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        using var tempDir = new TestTempDirectory();
+
+        var viteApp = builder.AddViteApp("viteapp", tempDir.Path)
+            .WithBrowserDebugger();
+
+        using var app = builder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var browserDebuggerResource = appModel.Resources.OfType<BrowserDebuggerResource>().Single();
+        // The BrowserDebuggerResource's command is the browser name
+        Assert.Equal("msedge", browserDebuggerResource.Command);
+    }
+
+    [Fact]
+    public void ViteApp_WithBrowserDebugger_UsesSpecifiedBrowser()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        using var tempDir = new TestTempDirectory();
+
+        var viteApp = builder.AddViteApp("viteapp", tempDir.Path)
+            .WithBrowserDebugger(browser: "chrome");
+
+        using var app = builder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var browserDebuggerResource = appModel.Resources.OfType<BrowserDebuggerResource>().Single();
+        Assert.Equal("chrome", browserDebuggerResource.Command);
+    }
+
+    [Fact]
+    public void ViteApp_WithBrowserDebugger_WithoutEndpoint_ThrowsInvalidOperationException()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        using var tempDir = new TestTempDirectory();
+
+        // Create a minimal JavaScriptAppResource without endpoints
+        var resource = new JavaScriptAppResource("jsapp", "npm", tempDir.Path);
+        var jsApp = builder.AddResource(resource);
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            jsApp.WithBrowserDebugger());
+
+        Assert.Contains("does not have an HTTP or HTTPS endpoint", exception.Message);
+    }
+
+#pragma warning restore ASPIREEXTENSION001 // Type is for evaluation purposes only
 }

--- a/tests/Aspire.Hosting.JavaScript.Tests/AddViteAppTests.cs
+++ b/tests/Aspire.Hosting.JavaScript.Tests/AddViteAppTests.cs
@@ -243,7 +243,7 @@ public class AddViteAppTests
         var nodeResource = Assert.Single(appModel.Resources.OfType<ViteAppResource>());
 
         // Get the command line args annotation to inspect the args callback
-        var commandLineArgsAnnotation = nodeResource.Annotations.OfType<CommandLineArgsCallbackAnnotation>().Single();
+        var commandLineArgsAnnotation = nodeResource.Annotations.OfType<CommandLineArgsCallbackAnnotation>().First();
         var args = new List<object>();
         var context = new CommandLineArgsCallbackContext(args, nodeResource);
         commandLineArgsAnnotation.Callback(context);
@@ -268,7 +268,7 @@ public class AddViteAppTests
         var nodeResource = Assert.Single(appModel.Resources.OfType<ViteAppResource>());
 
         // Get the command line args annotation to inspect the args callback
-        var commandLineArgsAnnotation = nodeResource.Annotations.OfType<CommandLineArgsCallbackAnnotation>().Single();
+        var commandLineArgsAnnotation = nodeResource.Annotations.OfType<CommandLineArgsCallbackAnnotation>().First();
         var args = new List<object>();
         var context = new CommandLineArgsCallbackContext(args, nodeResource);
         commandLineArgsAnnotation.Callback(context);

--- a/tests/Aspire.Hosting.JavaScript.Tests/AddViteAppWithPnpmTests.cs
+++ b/tests/Aspire.Hosting.JavaScript.Tests/AddViteAppWithPnpmTests.cs
@@ -28,7 +28,7 @@ public class AddViteAppWithPnpmTests
         Assert.Equal("run", packageManager.ScriptCommand);
 
         // Get the command line args annotation to inspect the args callback
-        var commandLineArgsAnnotation = nodeResource.Annotations.OfType<CommandLineArgsCallbackAnnotation>().Single();
+        var commandLineArgsAnnotation = nodeResource.Annotations.OfType<CommandLineArgsCallbackAnnotation>().First();
         var args = new List<object>();
         var context = new CommandLineArgsCallbackContext(args, nodeResource);
         commandLineArgsAnnotation.Callback(context);
@@ -62,7 +62,7 @@ public class AddViteAppWithPnpmTests
         Assert.Equal("run", packageManager.ScriptCommand);
 
         // Get the command line args annotation to inspect the args callback
-        var commandLineArgsAnnotation = nodeResource.Annotations.OfType<CommandLineArgsCallbackAnnotation>().Single();
+        var commandLineArgsAnnotation = nodeResource.Annotations.OfType<CommandLineArgsCallbackAnnotation>().First();
         var args = new List<object>();
         var context = new CommandLineArgsCallbackContext(args, nodeResource);
         commandLineArgsAnnotation.Callback(context);
@@ -90,7 +90,7 @@ public class AddViteAppWithPnpmTests
         Assert.Equal("npm", nodeResource.Command);
 
         // Get the command line args annotation to inspect the args callback
-        var commandLineArgsAnnotation = nodeResource.Annotations.OfType<CommandLineArgsCallbackAnnotation>().Single();
+        var commandLineArgsAnnotation = nodeResource.Annotations.OfType<CommandLineArgsCallbackAnnotation>().First();
         var args = new List<object>();
         var context = new CommandLineArgsCallbackContext(args, nodeResource);
         commandLineArgsAnnotation.Callback(context);
@@ -123,7 +123,7 @@ public class AddViteAppWithPnpmTests
         Assert.Equal("run", packageManager.ScriptCommand);
 
         // Get the command line args annotation to inspect the args callback
-        var commandLineArgsAnnotation = nodeResource.Annotations.OfType<CommandLineArgsCallbackAnnotation>().Single();
+        var commandLineArgsAnnotation = nodeResource.Annotations.OfType<CommandLineArgsCallbackAnnotation>().First();
         var args = new List<object>();
         var context = new CommandLineArgsCallbackContext(args, nodeResource);
         commandLineArgsAnnotation.Callback(context);

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -1656,7 +1656,7 @@ public class DcpExecutorTests
 
         // Create executable resources with SupportsDebuggingAnnotation
         var debuggableExecutable = new TestExecutableResource("test-working-directory");
-        builder.AddResource(debuggableExecutable).WithDebugSupport(mode => new ExecutableLaunchConfiguration("test") { Mode = mode }, "test");
+        builder.AddResource(debuggableExecutable).WithDebugSupport(options => new ExecutableLaunchConfiguration("test") { Mode = options.Mode }, "test");
 
         var nonDebuggableExecutable = new TestOtherExecutableResource("test-working-directory-2");
         // No SupportsDebuggingAnnotation for this one
@@ -2282,6 +2282,50 @@ public class DcpExecutorTests
             a => Assert.Equal(KnownResourceCommands.StartCommand, a.Name),
             a => Assert.Equal(KnownResourceCommands.StopCommand, a.Name),
             a => Assert.Equal(KnownResourceCommands.RestartCommand, a.Name));
+    }
+
+    [Fact]
+    public async Task PlainExecutable_LaunchConfigurationProducerThrows_FallsBackToProcess()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var debuggableExecutable = new TestExecutableResource("test-working-directory");
+        builder.AddResource(debuggableExecutable).WithDebugSupport<TestExecutableResource, ExecutableLaunchConfiguration>(_ => throw new InvalidOperationException("Test exception from launch configuration producer"), "test");
+
+        var runSessionInfo = new RunSessionInfo
+        {
+            ProtocolsSupported = ["test"],
+            SupportedLaunchConfigurations = ["test"]
+        };
+
+        var configDict = new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+            [KnownConfigNames.DebugSessionInfo] = JsonSerializer.Serialize(runSessionInfo),
+            [KnownConfigNames.ExtensionEndpoint] = "http://localhost:1234"
+        };
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+
+        await appExecutor.RunApplicationAsync();
+
+        List<Executable> dcpExes = [];
+        var haveExes = RetryTillTrueOrTimeout(() =>
+        {
+            dcpExes.Clear();
+            dcpExes.AddRange(kubernetesService.CreatedResources.OfType<Executable>());
+            return dcpExes.Count == 1;
+        }, TestConstants.DefaultOrchestratorTestTimeout);
+        Assert.True(haveExes, $"Expected one executable but instead got {dcpExes.Count}");
+
+        var exe = Assert.Single(dcpExes, e => e.AppModelResourceName == "TestExecutable");
+        // Should fall back to Process execution when the launch configuration producer throws
+        Assert.Equal(ExecutionType.Process, exe.Spec.ExecutionType);
     }
 
     private static DcpExecutor CreateAppExecutor(

--- a/tests/Aspire.Hosting.Tests/ExecutableResourceBuilderExtensionTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExecutableResourceBuilderExtensionTests.cs
@@ -83,7 +83,7 @@ public class ExecutableResourceBuilderExtensionTests
         var annotation = executable.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().SingleOrDefault();
         Assert.NotNull(annotation);
         var exe = new Executable(new ExecutableSpec());
-        annotation.LaunchConfigurationAnnotator(exe, "NoDebug");
+        annotation.LaunchConfigurationAnnotator(exe, new LaunchConfigurationProducerOptions { Mode = "NoDebug" });
         Assert.Equal("ms-python.python", annotation.LaunchConfigurationType);
 
         Assert.True(exe.TryGetAnnotationAsObjectList<ExecutableLaunchConfiguration>(Executable.LaunchConfigurationsAnnotation, out var annotations));


### PR DESCRIPTION
## Description

Re-implement JavaScript and browser debugging support for Aspire, replacing the reverted PR #14686.

**Key changes:**
- Deferred launch configuration pattern: annotator invocation is moved from `PreparePlainExecutables()` to `CreateExecutableAsync()` so that `endpointReference.Url` can be accessed after endpoints are allocated (fixes the "Hosting failed to start" crash)
- `LaunchConfigurationProducerOptions` class replaces the plain `string mode` parameter for richer context
- `WithBrowserDebugger()` and `WithVSCodeDebugging()` extension methods for JavaScript resources
- DcpExecutor falls back to `ExecutionType.Process` if the launch configuration producer throws
- Test coverage for all new functionality

Fixes the runtime crash when using `.WithBrowserDebugger()` that caused the original PR to be reverted.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
