### PR TITLE
Skip CodeLens for commented AppHost resources

### DIFF
--- a/extension/src/editor/parsers/csharpAppHostParser.ts
+++ b/extension/src/editor/parsers/csharpAppHostParser.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { AppHostResourceParser, ParsedResource, registerParser } from './AppHostResourceParser';
-import { findStatementStartLine, findFirstMatchOutsideComments } from './parserUtils';
+import { findStatementStartLine, findFirstMatchOutsideComments, findMatchesOutsideCommentsAndStrings } from './parserUtils';
 
 /**
  * C# AppHost resource parser.
@@ -26,9 +26,8 @@ class CSharpAppHostParser implements AppHostResourceParser {
 
         // Match .AddXyz("name") or .AddXyz<...>("name") patterns
         const addPattern = /\.(Add\w+)(?:<[^>]*>)?\s*\(\s*"([^"]+)"/g;
-        let match: RegExpExecArray | null;
 
-        while ((match = addPattern.exec(text)) !== null) {
+        for (const match of findMatchesOutsideCommentsAndStrings(text, addPattern)) {
             const methodName = match[1];
             const resourceName = match[2];
             const matchStart = match.index;

--- a/extension/src/editor/parsers/jsTsAppHostParser.ts
+++ b/extension/src/editor/parsers/jsTsAppHostParser.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { AppHostResourceParser, ParsedResource, registerParser } from './AppHostResourceParser';
-import { findStatementStartLine, findFirstMatchOutsideComments } from './parserUtils';
+import { findStatementStartLine, findFirstMatchOutsideComments, findMatchesOutsideCommentsAndStrings } from './parserUtils';
 
 /**
  * JavaScript / TypeScript AppHost resource parser.
@@ -26,9 +26,8 @@ class JsTsAppHostParser implements AppHostResourceParser {
         // Match .addXyz("name") or .addXyz('name') patterns
         // \s* matches whitespace including newlines, supporting multi-line calls
         const pattern = /\.(add\w+)\s*\(\s*(['"])([^'"]+)\2/gi;
-        let match: RegExpExecArray | null;
 
-        while ((match = pattern.exec(text)) !== null) {
+        for (const match of findMatchesOutsideCommentsAndStrings(text, pattern)) {
             const methodName = match[1];
             const resourceName = match[3];
 

--- a/extension/src/editor/parsers/parserUtils.ts
+++ b/extension/src/editor/parsers/parserUtils.ts
@@ -61,24 +61,48 @@ export function findStatementStartLine(text: string, matchIndex: number, documen
 }
 
 /**
- * Find the first match of `regex` whose line is not a comment line (// or /* / *).
- * Used to avoid matching builder-detection patterns inside header/block comments.
+ * Find matches whose starting character is in code rather than comments or strings.
+ *
+ * AppHost parsers still use targeted regexes to find resource-like calls, for example:
+ *   builder.AddContainer("api", "image"); // builder.AddContainer("disabled", "image")
+ *   /* builder.AddContainer("disabled", "image"); *\/
+ *   var sample = """builder.AddContainer("disabled", "image");""";
+ *
+ * VS Code's TextDocument API does not expose C#/JS semantic tokens synchronously to
+ * CodeLens providers, so the parsers first scan C-syntax trivia and string literals.
+ * This keeps regex matches for real code while ignoring line comments, block comments,
+ * trailing comments, escaped/verbatim/raw C# strings, and JS/TS template strings.
  * The regex must be created with the global flag.
  */
-export function findFirstMatchOutsideComments(text: string, regex: RegExp, document: vscode.TextDocument): RegExpExecArray | undefined {
+export function findMatchesOutsideCommentsAndStrings(text: string, regex: RegExp): RegExpExecArray[] {
     if (!regex.global) {
-        throw new Error('findFirstMatchOutsideComments requires a global regex');
+        throw new Error('findMatchesOutsideCommentsAndStrings requires a global regex');
     }
+
+    const inactiveRanges = getInactiveCodeRanges(text);
+    const results: RegExpExecArray[] = [];
+    regex.lastIndex = 0;
+
     let match: RegExpExecArray | null;
     while ((match = regex.exec(text)) !== null) {
-        const line = document.positionAt(match.index).line;
-        const lineText = document.lineAt(line).text.trimStart();
-        if (lineText.startsWith('//') || lineText.startsWith('/*') || lineText.startsWith('*')) {
-            continue;
+        if (!isInInactiveRange(inactiveRanges, match.index)) {
+            results.push(match);
         }
-        return match;
+
+        if (match[0].length === 0) {
+            regex.lastIndex++;
+        }
     }
-    return undefined;
+
+    return results;
+}
+
+/**
+ * Find the first match of `regex` whose starting character is in code.
+ * The regex must be created with the global flag.
+ */
+export function findFirstMatchOutsideComments(text: string, regex: RegExp, _document: vscode.TextDocument): RegExpExecArray | undefined {
+    return findMatchesOutsideCommentsAndStrings(text, regex)[0];
 }
 
 /**
@@ -108,4 +132,178 @@ export function isPrecededByArrow(text: string, openBraceIdx: number): boolean {
         k--;
     }
     return k >= 1 && text[k - 1] === '=' && text[k] === '>';
+}
+
+interface InactiveCodeRange {
+    start: number;
+    end: number;
+}
+
+function getInactiveCodeRanges(text: string): InactiveCodeRange[] {
+    const ranges: InactiveCodeRange[] = [];
+    let i = 0;
+
+    while (i < text.length) {
+        const rangeEnd =
+            tryReadLineCommentEnd(text, i)
+            ?? tryReadBlockCommentEnd(text, i)
+            ?? tryReadCSharpRawStringEnd(text, i)
+            ?? tryReadCSharpVerbatimStringEnd(text, i)
+            ?? tryReadPrefixedStringEnd(text, i)
+            ?? tryReadEscapedStringEnd(text, i, '"')
+            ?? tryReadEscapedStringEnd(text, i, "'")
+            ?? tryReadEscapedStringEnd(text, i, '`');
+
+        if (rangeEnd !== undefined) {
+            ranges.push({ start: i, end: rangeEnd });
+            i = rangeEnd;
+        } else {
+            i++;
+        }
+    }
+
+    return ranges;
+}
+
+function isInInactiveRange(ranges: readonly InactiveCodeRange[], index: number): boolean {
+    let low = 0;
+    let high = ranges.length - 1;
+
+    while (low <= high) {
+        const mid = Math.floor((low + high) / 2);
+        const range = ranges[mid];
+        if (index < range.start) {
+            high = mid - 1;
+        } else if (index >= range.end) {
+            low = mid + 1;
+        } else {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function tryReadLineCommentEnd(text: string, start: number): number | undefined {
+    if (text[start] !== '/' || text[start + 1] !== '/') {
+        return undefined;
+    }
+
+    const newlineIndex = text.indexOf('\n', start + 2);
+    return newlineIndex < 0 ? text.length : newlineIndex;
+}
+
+function tryReadBlockCommentEnd(text: string, start: number): number | undefined {
+    if (text[start] !== '/' || text[start + 1] !== '*') {
+        return undefined;
+    }
+
+    const endIndex = text.indexOf('*/', start + 2);
+    return endIndex < 0 ? text.length : endIndex + 2;
+}
+
+function tryReadCSharpRawStringEnd(text: string, start: number): number | undefined {
+    const delimiterStart = getRawStringDelimiterStart(text, start);
+    if (delimiterStart === undefined) {
+        return undefined;
+    }
+
+    const quoteCount = countConsecutive(text, delimiterStart, '"');
+    if (quoteCount < 3) {
+        return undefined;
+    }
+
+    let i = delimiterStart + quoteCount;
+    while (i < text.length) {
+        if (text[i] === '"' && countConsecutive(text, i, '"') >= quoteCount) {
+            return i + quoteCount;
+        }
+
+        i++;
+    }
+
+    return text.length;
+}
+
+function getRawStringDelimiterStart(text: string, start: number): number | undefined {
+    if (text[start] === '"') {
+        return start;
+    }
+
+    if (text[start] !== '$') {
+        return undefined;
+    }
+
+    let i = start;
+    while (text[i] === '$') {
+        i++;
+    }
+
+    return text[i] === '"' ? i : undefined;
+}
+
+function tryReadCSharpVerbatimStringEnd(text: string, start: number): number | undefined {
+    const quoteStart =
+        text[start] === '@' && text[start + 1] === '"'
+            ? start + 1
+            : text[start] === '$' && text[start + 1] === '@' && text[start + 2] === '"'
+                ? start + 2
+                : text[start] === '@' && text[start + 1] === '$' && text[start + 2] === '"'
+                    ? start + 2
+                    : undefined;
+
+    if (quoteStart === undefined) {
+        return undefined;
+    }
+
+    let i = quoteStart + 1;
+    while (i < text.length) {
+        if (text[i] === '"') {
+            if (text[i + 1] === '"') {
+                i += 2;
+            } else {
+                return i + 1;
+            }
+        } else {
+            i++;
+        }
+    }
+
+    return text.length;
+}
+
+function tryReadPrefixedStringEnd(text: string, start: number): number | undefined {
+    if (text[start] !== '$' || text[start + 1] !== '"') {
+        return undefined;
+    }
+
+    return tryReadEscapedStringEnd(text, start + 1, '"');
+}
+
+function tryReadEscapedStringEnd(text: string, start: number, quote: '"' | "'" | '`'): number | undefined {
+    if (text[start] !== quote) {
+        return undefined;
+    }
+
+    let i = start + 1;
+    while (i < text.length) {
+        if (text[i] === '\\') {
+            i += 2;
+        } else if (text[i] === quote) {
+            return i + 1;
+        } else {
+            i++;
+        }
+    }
+
+    return text.length;
+}
+
+function countConsecutive(text: string, start: number, ch: string): number {
+    let count = 0;
+    while (text[start + count] === ch) {
+        count++;
+    }
+
+    return count;
 }

--- a/extension/src/test/aspireCodeLensProvider.test.ts
+++ b/extension/src/test/aspireCodeLensProvider.test.ts
@@ -337,6 +337,156 @@ suite('AspireCodeLensProvider resource lens anchoring', () => {
         );
     }
 
+    function getStateLenses(lenses: vscode.CodeLens[]): vscode.CodeLens[] {
+        return lenses.filter(l => l.command?.command === 'aspire-vscode.codeLensRevealResource');
+    }
+
+    test('does not emit resource state lenses for line-commented C# resource calls', () => {
+        const docPath = p('repo', 'AppHost', 'AppHost.cs');
+        const hostPath = p('repo', 'AppHost', 'AppHost.csproj');
+        const content = [
+            'var builder = DistributedApplication.CreateBuilder(args);',
+            'builder.AddContainer("active", "nginx");',
+            '// builder.AddContainer("active", "nginx");',
+            '    //builder.AddContainer("line-commented", "nginx");',
+        ].join('\n');
+
+        const harness = createHarness({
+            workspaceAppHostPath: hostPath,
+            workspaceResources: [
+                makeResource('active'),
+                makeResource('line-commented'),
+            ],
+        });
+
+        const doc = createMockDocument(content, docPath);
+        const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
+        const stateLenses = getStateLenses(lenses);
+
+        assert.strictEqual(stateLenses.length, 1);
+        assert.strictEqual(stateLenses[0].range.start.line, 1);
+        harness.dispose();
+    });
+
+    test('does not emit resource state lenses for block-commented C# resource calls', () => {
+        const docPath = p('repo', 'AppHost', 'AppHost.cs');
+        const hostPath = p('repo', 'AppHost', 'AppHost.csproj');
+        const content = [
+            'var builder = DistributedApplication.CreateBuilder(args);',
+            '/*',
+            'builder.AddContainer("block-commented", "nginx");',
+            'nested-looking block opener /* does not make this active',
+            'builder.AddContainer("also-block-commented", "nginx");',
+            '*/',
+            'builder.AddContainer("active", "nginx");',
+        ].join('\n');
+
+        const harness = createHarness({
+            workspaceAppHostPath: hostPath,
+            workspaceResources: [
+                makeResource('active'),
+                makeResource('block-commented'),
+                makeResource('also-block-commented'),
+            ],
+        });
+
+        const doc = createMockDocument(content, docPath);
+        const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
+        const stateLenses = getStateLenses(lenses);
+
+        assert.strictEqual(stateLenses.length, 1);
+        assert.strictEqual(stateLenses[0].range.start.line, 6);
+        harness.dispose();
+    });
+
+    test('does not emit resource state lenses for C# resource calls in trailing comments', () => {
+        const docPath = p('repo', 'AppHost', 'AppHost.cs');
+        const hostPath = p('repo', 'AppHost', 'AppHost.csproj');
+        const content = [
+            'var builder = DistributedApplication.CreateBuilder(args);',
+            'builder.AddContainer("active", "nginx"); // builder.AddContainer("trailing-commented", "nginx");',
+        ].join('\n');
+
+        const harness = createHarness({
+            workspaceAppHostPath: hostPath,
+            workspaceResources: [
+                makeResource('active'),
+                makeResource('trailing-commented'),
+            ],
+        });
+
+        const doc = createMockDocument(content, docPath);
+        const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
+        const stateLenses = getStateLenses(lenses);
+
+        assert.strictEqual(stateLenses.length, 1);
+        assert.strictEqual(stateLenses[0].range.start.line, 1);
+        harness.dispose();
+    });
+
+    test('does not emit resource state lenses for C# resource calls inside strings', () => {
+        const docPath = p('repo', 'AppHost', 'AppHost.cs');
+        const hostPath = p('repo', 'AppHost', 'AppHost.csproj');
+        const content = [
+            'var builder = DistributedApplication.CreateBuilder(args);',
+            'var escaped = "builder.AddContainer(\\"escaped\\", \\"nginx\\")";',
+            'var verbatim = @"builder.AddContainer(""verbatim"", ""nginx"")";',
+            'var interpolatedVerbatim = $@"builder.AddContainer(""interpolated-verbatim"", ""nginx"")";',
+            'var raw = """',
+            'builder.AddContainer("raw", "nginx");',
+            '""";',
+            'var interpolatedRaw = $"""',
+            'builder.AddContainer("interpolated-raw", "nginx");',
+            '""";',
+            'builder.AddContainer("active", "nginx");',
+        ].join('\n');
+
+        const harness = createHarness({
+            workspaceAppHostPath: hostPath,
+            workspaceResources: [
+                makeResource('active'),
+                makeResource('escaped'),
+                makeResource('verbatim'),
+                makeResource('interpolated-verbatim'),
+                makeResource('raw'),
+                makeResource('interpolated-raw'),
+            ],
+        });
+
+        const doc = createMockDocument(content, docPath);
+        const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
+        const stateLenses = getStateLenses(lenses);
+
+        assert.strictEqual(stateLenses.length, 1);
+        assert.strictEqual(stateLenses[0].range.start.line, 10);
+        harness.dispose();
+    });
+
+    test('still emits resource state lenses for active C# resource calls with whitespace', () => {
+        const docPath = p('repo', 'AppHost', 'AppHost.cs');
+        const hostPath = p('repo', 'AppHost', 'AppHost.csproj');
+        const content = [
+            'var builder = DistributedApplication.CreateBuilder(args);',
+            'var active = builder',
+            '    .AddContainer(',
+            '        "active",',
+            '        "nginx");',
+        ].join('\n');
+
+        const harness = createHarness({
+            workspaceAppHostPath: hostPath,
+            workspaceResources: [makeResource('active')],
+        });
+
+        const doc = createMockDocument(content, docPath);
+        const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
+        const stateLenses = getStateLenses(lenses);
+
+        assert.strictEqual(stateLenses.length, 1);
+        assert.strictEqual(stateLenses[0].range.start.line, 1);
+        harness.dispose();
+    });
+
     test('single-resource fluent chain anchors lens at the statement-start line, not the .add* call line', () => {
         const docPath = p('repo', 'AppHost', 'apphost.ts');
         const hostPath = p('repo', 'AppHost', 'apphost.ts');

--- a/extension/src/test/parsers.test.ts
+++ b/extension/src/test/parsers.test.ts
@@ -446,7 +446,7 @@ suite('CSharpAppHostParser', () => {
         assert.strictEqual(resources.length, 0, 'C# parser should only match PascalCase Add* methods');
     });
 
-    test('matches Add* calls in commented-out code (known regex limitation)', () => {
+    test('does not match Add* calls in commented-out C# code', () => {
         const parser = getCSharpParser();
         const doc = createMockDocument(
             [
@@ -457,9 +457,8 @@ suite('CSharpAppHostParser', () => {
             '/test/AppHost.cs'
         );
         const resources = parser.parseResources(doc);
-        // Regex-based parser cannot distinguish comments from code — all three match
-        assert.strictEqual(resources.length, 3);
-        assert.strictEqual(resources[2].name, 'real-cache');
+        assert.strictEqual(resources.length, 1);
+        assert.strictEqual(resources[0].name, 'real-cache');
     });
 
     test('does not match string interpolation expressions', () => {
@@ -1297,7 +1296,7 @@ suite('JsTsAppHostParser', () => {
         assert.strictEqual(resources.length, 0);
     });
 
-    test('matches add* calls in commented-out code (known regex limitation)', () => {
+    test('does not match add* calls in commented-out JS/TS code', () => {
         const parser = getJsTsParser();
         const doc = createMockDocument(
             [
@@ -1308,9 +1307,8 @@ suite('JsTsAppHostParser', () => {
             '/test/apphost.ts'
         );
         const resources = parser.parseResources(doc);
-        // Regex-based parser cannot distinguish comments from code — all three match
-        assert.strictEqual(resources.length, 3);
-        assert.strictEqual(resources[2].name, 'real-cache');
+        assert.strictEqual(resources.length, 1);
+        assert.strictEqual(resources[0].name, 'real-cache');
     });
 
     test('does not match template literal arguments', () => {


### PR DESCRIPTION
## Description

Fixes microsoft/aspire#16937.

RCA: the VS Code extension resource parsers found AppHost resources with broad `Add*` / `add*` regexes over the entire document. Those matches were not filtered for comment or string trivia, so live resource state CodeLens entries could attach to commented-out `builder.AddContainer(...)` examples.

Why fix: commented resources should not appear as active resources in the editor, especially when active and commented declarations share a name.

### How I reproduced the original issue

Environment/setup:

- VS Code extension dev/test host with an AppHost source file open.
- An AppHost file containing both real resource declarations and commented/string-literal text that looks like resource declarations.
- Live CodeLens data is normally produced after the extension has AppHost resource state, but the bug is in the parser layer that maps source locations to resource names.

Manual repro path from the issue:

1. Open an AppHost file in VS Code Insiders with this shape:

   ```csharp
   var builder = DistributedApplication.CreateBuilder(args);

   builder.AddContainer("unleash-app", "whatever", "whatever");

   //builder.AddContainer("unleash-app", "whatever", "whatever");

   /*
   builder.AddContainer("unleash-app", "whatever", "whatever");
   */
   ```

2. Start the Aspire extension/AppHost so resource CodeLens entries are available.
3. Before the fix, the extension could attach resource status CodeLens entries to the commented `AddContainer` lines even though those lines are not active resources.

Automated repro used for the fix:

- Focused parser tests feed C# and JS/TS document text containing line comments, block comments, trailing comments, string literals, and active resource calls.
- Those tests failed on the old parser because commented/string-literal `Add*` calls were returned as real resources, then passed once matches inside comments/strings were filtered.

### Fix details

- Added a shared parser helper that filters regex matches whose start is inside line comments, block comments, trailing comments, or string literals.
- Covered C# escaped, verbatim, interpolated verbatim, raw, and interpolated raw strings plus JS/TS template strings.
- Updated C# and JS/TS resource parsers to use the filtered matches.

### Tests / validation

- Focused RED tests initially failed for line comments, block comments, trailing comments, strings, and active `AddContainer` code.
- `npm run compile-tests --silent && npm run compile --silent && npm run lint --silent && npm run unit-test --silent` (479 passing)
- VS Code Insiders smoke: `npm run unit-test -- --code-version insiders --grep "line-commented C# resource calls|block-commented C# resource calls|trailing comments|inside strings|active C# resource calls with whitespace"` (5 passing)
- Local code-review pass: no actionable findings.
- Local PR-testing equivalent: extension compile/lint/unit tests plus Insiders focused smoke; no separate dogfood comment available in this isolated worktree.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
