### PR TITLE
Improve VS Code parameter display

### DIFF
--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -529,6 +529,9 @@
     <trans-unit id="configuration.aspire.dashboardBrowser.openExternalBrowser">
       <source xml:lang="en">Use the system default browser (cannot auto-close).</source>
     </trans-unit>
+    <trans-unit id="aspire-vscode.strings.parameterValueMissing">
+      <source xml:lang="en">Value missing</source>
+    </trans-unit>
     <trans-unit id="aspire-vscode.strings.resourceCommandMaxLength">
       <source xml:lang="en">Value must be {0} characters or fewer.</source>
     </trans-unit>

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -188,5 +188,6 @@
   "aspire-vscode.strings.resourceCommandContinue": "Continue",
   "aspire-vscode.strings.resourceCommandDontShowAgain": "Don't show again",
   "aspire-vscode.strings.resourceCommandInvalidNumber": "Enter a number using invariant culture, for example 1, -1.5, or 1e3.",
-  "aspire-vscode.strings.resourceCommandMaxLength": "Value must be {0} characters or fewer."
+  "aspire-vscode.strings.resourceCommandMaxLength": "Value must be {0} characters or fewer.",
+  "aspire-vscode.strings.parameterValueMissing": "Value missing"
 }

--- a/extension/src/editor/resourceConstants.ts
+++ b/extension/src/editor/resourceConstants.ts
@@ -12,6 +12,7 @@ export const ResourceState = {
     Exited: 'Exited',
     FailedToStart: 'FailedToStart',
     RuntimeUnhealthy: 'RuntimeUnhealthy',
+    ValueMissing: 'ValueMissing',
 } as const;
 
 // Health status values returned by the Aspire runtime

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -81,6 +81,7 @@ export const healthChecksLabel = vscode.l10n.t('Health Checks');
 export const healthCheckDescription = (status: string) => vscode.l10n.t('Status: {0}', status);
 export const resourceDescriptionHealth = (passed: number, total: number) => vscode.l10n.t('Health: {0}/{1}', passed, total);
 export const resourceDescriptionExitCode = (exitCode: number) => vscode.l10n.t('Exit Code: {0}', exitCode);
+export const parameterValueMissing = vscode.l10n.t('Value missing');
 export const failedToStartDebugSession = vscode.l10n.t('Failed to start debug session.');
 export const failedToGetConfigInfo = (exitCode: number) => vscode.l10n.t('Failed to get Aspire config info (exit code: {0}). Try updating the Aspire CLI with: aspire update', exitCode);
 export const failedToParseConfigInfo = (error: any) => vscode.l10n.t('Failed to parse Aspire config info: {0}. Try updating the Aspire CLI with: aspire update', error);

--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -6,6 +6,7 @@ import * as cliModule from '../debugger/languages/cli';
 import { AppHostDataRepository, shortenPath, shortenPaths } from '../views/AppHostDataRepository';
 import { AspireAppHostTreeProvider, getResourceContextValue, getResourceIcon, resolveAppHostSourcePath, buildResourceDescription } from '../views/AspireAppHostTreeProvider';
 import type { AppHostDisplayInfo, ResourceJson, ViewMode } from '../views/AppHostDataRepository';
+import { ResourceCommandInputType } from '../views/AppHostDataRepository';
 import { ResourceState, HealthStatus, StateStyle } from '../editor/resourceConstants';
 import type { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
 
@@ -490,6 +491,15 @@ suite('getResourceIcon', () => {
         const icon = getResourceIcon(makeResource({ state: 'SomeUnknownState' }));
         assert.strictEqual(icon.id, 'circle-filled');
     });
+
+    test('ValueMissing parameter shows warning icon', () => {
+        const icon = getResourceIcon(makeResource({
+            resourceType: 'Parameter',
+            state: 'ValueMissing',
+        }));
+
+        assert.strictEqual(icon.id, 'warning');
+    });
 });
 
 suite('buildResourceDescription', () => {
@@ -529,6 +539,86 @@ suite('buildResourceDescription', () => {
 
     test('empty health reports returns resource type', () => {
         assert.strictEqual(buildResourceDescription(makeResource({ healthReports: {} })), 'Project');
+    });
+
+    test('parameter with missing value shows humanized state and no stale value', () => {
+        const desc = buildResourceDescription(makeResource({
+            resourceType: 'Parameter',
+            state: ResourceState.ValueMissing,
+            properties: { Value: 'Parameter value has been deleted' },
+        }));
+
+        assert.strictEqual(desc, 'Parameter · Value missing');
+    });
+
+    test('parameter with non-secret value shows value text', () => {
+        const desc = buildResourceDescription(makeResource({
+            resourceType: 'Parameter',
+            state: ResourceState.Running,
+            properties: { Value: 'The value' },
+        }));
+
+        assert.strictEqual(desc, 'Parameter · Running · The value');
+    });
+
+    test('parameter with secret value shows masked value', () => {
+        const desc = buildResourceDescription(makeResource({
+            resourceType: 'Parameter',
+            state: ResourceState.Running,
+            properties: { Value: 'super-secret-value' },
+            commands: {
+                'set-parameter': {
+                    displayName: 'Set parameter',
+                    description: null,
+                    argumentInputs: [
+                        {
+                            name: 'Value',
+                            label: null,
+                            description: null,
+                            inputType: ResourceCommandInputType.SecretText,
+                            placeholder: null,
+                            value: null,
+                            options: null,
+                            maxLength: null,
+                        },
+                    ],
+                },
+            },
+        }));
+
+        assert.strictEqual(desc, 'Parameter · Running · ●●●●●●●●');
+        assert.ok(!desc.includes('super-secret-value'), 'Expected secret value to be masked');
+    });
+
+    test('parameter value at display limit is not truncated', () => {
+        const value = 'x'.repeat(80);
+        const desc = buildResourceDescription(makeResource({
+            resourceType: 'Parameter',
+            state: ResourceState.Running,
+            properties: { Value: value },
+        }));
+
+        assert.strictEqual(desc, `Parameter · Running · ${value}`);
+    });
+
+    test('parameter value over display limit is truncated with ellipsis', () => {
+        const desc = buildResourceDescription(makeResource({
+            resourceType: 'Parameter',
+            state: ResourceState.Running,
+            properties: { Value: `${'x'.repeat(80)}y` },
+        }));
+
+        assert.strictEqual(desc, `Parameter · Running · ${'x'.repeat(79)}…`);
+    });
+
+    test('parameter with empty value does not add a blank value segment', () => {
+        const desc = buildResourceDescription(makeResource({
+            resourceType: 'Parameter',
+            state: ResourceState.Running,
+            properties: { Value: '' },
+        }));
+
+        assert.strictEqual(desc, 'Parameter · Running');
     });
 });
 
@@ -709,6 +799,60 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
         assert.ok(resultA);
         assert.ok(resultB);
         assert.notStrictEqual(resultA, resultB, 'Expected distinct items for distinct AppHosts');
+        provider.dispose();
+    });
+
+    test('resource command quick pick preserves command order from resource data', async () => {
+        const sandbox = sinon.createSandbox();
+        const resource = makeResource({
+            commands: {
+                'set-parameter': { displayName: 'Set parameter', description: null },
+                'custom-action': { displayName: 'Custom action', description: null },
+                'delete-parameter': { displayName: 'Delete parameter', description: null },
+            },
+        });
+        const provider = makeTreeProvider([
+            makeAppHost({
+                resources: [resource],
+            }),
+        ]);
+
+        try {
+            const showQuickPickStub = sandbox.stub(vscode.window, 'showQuickPick').resolves(undefined);
+            const element = provider.findResourceElement('my-service');
+            assert.ok(element, 'Expected to find resource element');
+
+            await provider.executeResourceCommand(element as never);
+
+            const items = showQuickPickStub.getCall(0).args[0] as readonly vscode.QuickPickItem[];
+            assert.deepStrictEqual(items.map(item => item.label), [
+                'set-parameter',
+                'custom-action',
+                'delete-parameter',
+            ]);
+        } finally {
+            sandbox.restore();
+            provider.dispose();
+        }
+    });
+
+    test('parameter missing value tooltip uses humanized state', () => {
+        const resource = makeResource({
+            resourceType: 'Parameter',
+            state: ResourceState.ValueMissing,
+        });
+        const provider = makeTreeProvider([
+            makeAppHost({
+                resources: [resource],
+            }),
+        ]);
+        const [appHostItem] = provider.getChildren();
+        const resourcesGroup = provider.getChildren(appHostItem).find(child => child.label === 'Resources');
+        assert.ok(resourcesGroup, 'Expected resources group');
+        const [resourceItem] = provider.getChildren(resourcesGroup);
+        const tooltip = resourceItem.tooltip as vscode.MarkdownString;
+
+        assert.ok(tooltip.value.includes('State: Value missing'), tooltip.value);
         provider.dispose();
     });
 });

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
-import { ResourceState, HealthStatus, StateStyle } from '../editor/resourceConstants';
+import { ResourceState, HealthStatus, ResourceType, StateStyle } from '../editor/resourceConstants';
 import {
     pidDescription,
     dashboardLabel,
@@ -22,6 +22,7 @@ import {
     appHostSourceOpenFailed,
     healthChecksLabel,
     healthCheckDescription,
+    parameterValueMissing,
     resourceDescriptionHealth,
     resourceDescriptionExitCode,
 } from '../loc/strings';
@@ -32,10 +33,18 @@ import {
     ResourceJson,
     ViewMode,
     shortenPaths,
+    ResourceCommandInputType,
+    ResourceCommandJson,
 } from './AppHostDataRepository';
 import { collectResourceCommandArguments, hasSecretResourceCommandArguments } from './ResourceCommandArguments';
 
 type TreeElement = AppHostItem | PidItem | EndpointUrlItem | ResourcesGroupItem | ResourceItem | WorkspaceResourcesItem | HealthChecksGroupItem | HealthCheckItem;
+
+const setParameterCommandName = 'set-parameter';
+const deleteParameterCommandName = 'delete-parameter';
+const parameterValuePropertyName = 'Value';
+const maxParameterValueDisplayLength = 80;
+const maskedParameterValue = '●●●●●●●●';
 
 function sortResources(resources: ResourceJson[]): ResourceJson[] {
     return [...resources].sort((a, b) => {
@@ -196,6 +205,8 @@ export function getResourceIcon(resource: ResourceJson): vscode.ThemeIcon {
     const state = resource.state;
     const health = resource.healthStatus;
     switch (state) {
+        case ResourceState.ValueMissing:
+            return new vscode.ThemeIcon('warning', new vscode.ThemeColor('list.warningForeground'));
         case ResourceState.Running:
         case ResourceState.Active:
             if (resource.stateStyle === StateStyle.Error) {
@@ -269,7 +280,11 @@ export function buildResourceDescription(resource: ResourceJson): string {
     const parts: string[] = [resource.resourceType];
     const state = resource.state;
     if (state) {
-        parts.push(state);
+        parts.push(getResourceStateDescription(state));
+    }
+    const parameterValue = getParameterValueDescription(resource);
+    if (parameterValue) {
+        parts.push(parameterValue);
     }
     const reports = resource.healthReports;
     const exitCode = resource.exitCode;
@@ -284,12 +299,52 @@ export function buildResourceDescription(resource: ResourceJson): string {
     return parts.join(' · ');
 }
 
+function getResourceStateDescription(state: string): string {
+    return state === ResourceState.ValueMissing ? parameterValueMissing : state;
+}
+
+function getParameterValueDescription(resource: ResourceJson): string | undefined {
+    if (resource.resourceType !== ResourceType.Parameter || resource.state === ResourceState.ValueMissing) {
+        return undefined;
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(resource.properties ?? {}, parameterValuePropertyName)) {
+        return undefined;
+    }
+
+    if (isSecretParameter(resource)) {
+        return maskedParameterValue;
+    }
+
+    const value = resource.properties?.[parameterValuePropertyName];
+    if (typeof value !== 'string' || value.length === 0) {
+        return undefined;
+    }
+
+    return truncateParameterValue(value);
+}
+
+function isSecretParameter(resource: ResourceJson): boolean {
+    const setParameterCommand = resource.commands?.[setParameterCommandName];
+    return setParameterCommand?.argumentInputs?.some(input =>
+        input.name === parameterValuePropertyName &&
+        input.inputType === ResourceCommandInputType.SecretText) ?? false;
+}
+
+function truncateParameterValue(value: string): string {
+    if (value.length <= maxParameterValueDisplayLength) {
+        return value;
+    }
+
+    return `${value.slice(0, maxParameterValueDisplayLength - 1)}…`;
+}
+
 function buildResourceTooltip(resource: ResourceJson): vscode.MarkdownString {
     const md = new vscode.MarkdownString();
     md.appendMarkdown(`**${resource.displayName ?? resource.name}**\n\n`);
     md.appendMarkdown(`${tooltipType(resource.resourceType)}\n\n`);
     if (resource.state) {
-        md.appendMarkdown(`${tooltipState(resource.state)}\n\n`);
+        md.appendMarkdown(`${tooltipState(getResourceStateDescription(resource.state))}\n\n`);
     }
     if (resource.healthStatus) {
         md.appendMarkdown(`${tooltipHealth(resource.healthStatus)}\n\n`);

--- a/src/Aspire.Cli/Backchannel/ResourceSnapshotMapper.cs
+++ b/src/Aspire.Cli/Backchannel/ResourceSnapshotMapper.cs
@@ -109,7 +109,6 @@ internal static class ResourceSnapshotMapper
         // Only include enabled commands
         var commands = snapshot.Commands
             .Where(IsCommandAvailableToApi)
-            .OrderBy(c => c.Name)
             .ToDistinctDictionary(
                 c => c.Name,
                 c => new ResourceCommandJson

--- a/tests/Aspire.Cli.Tests/Backchannel/ResourceSnapshotMapperTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/ResourceSnapshotMapperTests.cs
@@ -127,6 +127,30 @@ public class ResourceSnapshotMapperTests
     }
 
     [Fact]
+    public void MapToResourceJson_PreservesCommandSnapshotOrder()
+    {
+        var snapshot = new ResourceSnapshot
+        {
+            Name = "parameter",
+            DisplayName = "parameter",
+            ResourceType = "Parameter",
+            State = "Running",
+            Commands =
+            [
+                new ResourceSnapshotCommand { Name = "set-parameter", State = "Enabled", Description = "Set", Visibility = KnownCommandVisibility.Api },
+                new ResourceSnapshotCommand { Name = "custom-action", State = "Enabled", Description = "Custom", Visibility = KnownCommandVisibility.Api },
+                new ResourceSnapshotCommand { Name = "delete-parameter", State = "Enabled", Description = "Delete", Visibility = KnownCommandVisibility.Api }
+            ]
+        };
+
+        var result = ResourceSnapshotMapper.MapToResourceJson(snapshot, [snapshot]);
+
+        Assert.Equal(
+            ["set-parameter", "custom-action", "delete-parameter"],
+            result.Commands!.Keys);
+    }
+
+    [Fact]
     public void MapToResourceJson_ResolvesWaitingForDependencies()
     {
         var dependency = new ResourceSnapshot


### PR DESCRIPTION
## Description

Fixes microsoft/aspire#17193.

The VS Code extension resource tree previously showed raw parameter runtime state/value data, so a missing parameter appeared as `ValueMissing` and stale deleted-value text could be surfaced in the tree. It also hid useful non-secret parameter values and listed parameter commands in alphabetical CLI payload order, which put `delete-parameter` before `set-parameter`.

This change aligns the VS Code tree behavior with the Aspire dashboard:

- Shows missing parameter values as localized `Value missing` text with a warning icon.
- Shows non-secret parameter values directly in the resource row, truncated to 80 displayed characters.
- Masks secret parameter values as `●●●●●●●●`.
- Preserves resource command order from the AppHost model through the CLI JSON payload so parameter resources naturally show `set-parameter` before `delete-parameter` without hardcoding command order in the extension.

### User-facing usage

When a parameter resource is missing a value, users now see a warning row like:

```text
Parameter · Value missing
```

When a parameter has a non-secret value, users now see it inline:

```text
Parameter · Running · The value
```

Secret parameters remain masked:

```text
Parameter · Running · ●●●●●●●●
```

### How I reproduced the original issue

Environment/setup:

- VS Code Insiders extension test host or a VS Code workspace running an Aspire AppHost.
- An AppHost with parameter resources covering three states: missing required value, non-secret value, and secret value.
- The Aspire resource tree populated from the CLI/backchannel resource JSON.

Manual repro path:

1. Start the AppHost and open the Aspire resource tree in VS Code.
2. Before the fix, the missing parameter row displays raw `ValueMissing` text instead of dashboard-style `Value missing` with a warning icon.
3. Before the fix, non-secret parameter values are not shown inline in the resource row.
4. Open the parameter resource command quick pick; before the fix, `delete-parameter` can appear before `set-parameter` because the CLI backchannel payload is alphabetized by command name.

Automated repro used for the fix:

- Extension tests feed mocked parameter resource JSON into the tree provider for missing, non-secret, and secret parameter rows.
- A VS Code quick-pick test verifies command display order follows the command order in resource data.
- A CLI mapper regression test feeds commands in AppHost/resource-snapshot order and verifies serialized JSON keys preserve that order; the old `.OrderBy(c => c.Name)` path fails that expectation.

### Root cause

The extension rendered resource state strings directly and did not have special handling for the dashboard's `ValueMissing` parameter state. Parameter values were not included in tree descriptions.

For parameter command ordering, the CLI backchannel serialized resource commands with `.OrderBy(c => c.Name)`. JavaScript preserves insertion order for string object keys, so the extension faithfully displayed the alphabetized CLI payload and surfaced `delete-parameter` before `set-parameter`.

### Why this fix

Parameter rows should be readable and safe in the VS Code tree: missing values should look like the dashboard, non-secret values should be visible, and secret values should remain masked. Command quick picks should reflect the AppHost/dashboard command order rather than duplicating a command-priority table in the extension.

### Fix details

- Added parameter-specific tree display handling for missing, non-secret, and secret values.
- Removed CLI command-name sorting from `ResourceSnapshotMapper` so serialized command key order follows the resource snapshot/app model.
- Kept the extension quick pick as a simple enumeration of the resource command payload, avoiding hardcoded command ordering.
- Added unit coverage for parameter display, command quick-pick order, and CLI command-order preservation.

### Manual testing

1. Open an Aspire AppHost in VS Code Insiders with a parameter resource.
2. Confirm missing parameter values display as `Value missing` with the warning icon.
3. Set a non-secret parameter value and confirm it appears inline in the resource tree.
4. Confirm secret parameter values are masked as `●●●●●●●●`.
5. Open the parameter command quick pick and confirm `set-parameter` appears before `delete-parameter` while custom commands remain in the order provided by the AppHost/CLI payload.

### Validation

- `npm run compile-tests -- --pretty false`
- `npm run lint -- --quiet`
- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.ResourceSnapshotMapperTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `npx vscode-test --config /Users/adamratzman/.copilot/session-state/a0830ed5-8fac-4cc4-90cf-a2d2f0166303/files/vscode-test-short-17193.mjs --grep "ValueMissing|parameter with|parameter value|resource command quick pick|parameter missing value tooltip" --reporter dot`
- `npm run compile -- --mode development` (succeeded; existing optional webpack dependency warnings and schema-generation skip because the Aspire CLI binary was not built)
- `git diff --check`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
