### PR TITLE
Add command to open dashboard to the side

### DIFF
--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -358,6 +358,9 @@
     <trans-unit id="command.openDashboard">
       <source xml:lang="en">Open Aspire Dashboard</source>
     </trans-unit>
+    <trans-unit id="command.openDashboardToSide">
+      <source xml:lang="en">Open Aspire Dashboard to the Side</source>
+    </trans-unit>
     <trans-unit id="command.openTerminal">
       <source xml:lang="en">Open Aspire terminal</source>
     </trans-unit>

--- a/extension/package.json
+++ b/extension/package.json
@@ -273,6 +273,11 @@
         "icon": "$(globe)"
       },
       {
+        "command": "aspire-vscode.openDashboardToSide",
+        "title": "%command.openDashboardToSide%",
+        "category": "Aspire"
+      },
+      {
         "command": "aspire-vscode.openAppHostSource",
         "title": "%command.openAppHostSource%",
         "category": "Aspire",
@@ -468,6 +473,10 @@
         },
         {
           "command": "aspire-vscode.openDashboard",
+          "when": "!aspire.noRunningAppHosts"
+        },
+        {
+          "command": "aspire-vscode.openDashboardToSide",
           "when": "!aspire.noRunningAppHosts"
         },
         {

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -139,6 +139,7 @@
   "views.runningAppHosts.errorWelcome": "The Aspire CLI is not installed or does not support this feature. Install or update the Aspire CLI and restart VS Code to get started.\n[Update Aspire CLI](command:aspire-vscode.updateSelf)\n[Refresh](command:aspire-vscode.refreshRunningAppHosts)",
   "command.refreshRunningAppHosts": "Refresh running AppHosts",
   "command.openDashboard": "Open Aspire Dashboard",
+  "command.openDashboardToSide": "Open Aspire Dashboard to the Side",
   "command.openAppHostSource": "Open AppHost source",
   "command.stopAppHost": "Stop",
   "command.stopResource": "Stop",

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -107,6 +107,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const switchToGlobalViewRegistration = vscode.commands.registerCommand('aspire-vscode.switchToGlobalView', () => dataRepository.setViewMode('global'));
   const switchToWorkspaceViewRegistration = vscode.commands.registerCommand('aspire-vscode.switchToWorkspaceView', () => dataRepository.setViewMode('workspace'));
   const openDashboardRegistration = vscode.commands.registerCommand('aspire-vscode.openDashboard', (element) => appHostTreeProvider.openDashboard(element));
+  const openDashboardToSideRegistration = vscode.commands.registerCommand('aspire-vscode.openDashboardToSide', (element) => appHostTreeProvider.openDashboardToSide(element));
   const openAppHostSourceRegistration = vscode.commands.registerCommand('aspire-vscode.openAppHostSource', (element) => appHostTreeProvider.openAppHostSource(element));
   const stopAppHostRegistration = vscode.commands.registerCommand('aspire-vscode.stopAppHost', (element) => appHostTreeProvider.stopAppHost(element));
   const stopResourceRegistration = vscode.commands.registerCommand('aspire-vscode.stopResource', (element) => appHostTreeProvider.stopResource(element));
@@ -129,7 +130,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Activate the data repository. Workspace describe watching and global polling begin when the panel is visible.
   dataRepository.activate();
 
-  context.subscriptions.push(appHostTreeView, refreshRunningAppHostsRegistration, switchToGlobalViewRegistration, switchToWorkspaceViewRegistration, openDashboardRegistration, openAppHostSourceRegistration, stopAppHostRegistration, stopResourceRegistration, startResourceRegistration, restartResourceRegistration, viewResourceLogsRegistration, executeResourceCommandRegistration, copyEndpointUrlRegistration, openInExternalBrowserRegistration, openInIntegratedBrowserRegistration, copyResourceNameRegistration, copyPidRegistration, copyAppHostPathRegistration, expandAllRegistration, { dispose: () => { appHostTreeProvider.dispose(); dataRepository.dispose(); } });
+  context.subscriptions.push(appHostTreeView, refreshRunningAppHostsRegistration, switchToGlobalViewRegistration, switchToWorkspaceViewRegistration, openDashboardRegistration, openDashboardToSideRegistration, openAppHostSourceRegistration, stopAppHostRegistration, stopResourceRegistration, startResourceRegistration, restartResourceRegistration, viewResourceLogsRegistration, executeResourceCommandRegistration, copyEndpointUrlRegistration, openInExternalBrowserRegistration, openInIntegratedBrowserRegistration, copyResourceNameRegistration, copyPidRegistration, copyAppHostPathRegistration, expandAllRegistration, { dispose: () => { appHostTreeProvider.dispose(); dataRepository.dispose(); } });
 
   // CodeLens provider — shows Debug on pipeline steps, resource state on resources
   const codeLensProvider = new AspireCodeLensProvider(appHostTreeProvider, dataRepository);

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -9,6 +9,7 @@ export const codespacesUrl = (url: string) => vscode.l10n.t('Codespaces: {0}', u
 export const directLink = vscode.l10n.t('Open local URL');
 export const codespacesLink = vscode.l10n.t('Open codespaces URL');
 export const openAspireDashboard = vscode.l10n.t('Launch Aspire Dashboard');
+export const openAspireDashboardToSide = vscode.l10n.t('Open Aspire Dashboard to the Side');
 export const settingsLabel = vscode.l10n.t('Settings');
 export const aspireDashboard = vscode.l10n.t('Aspire Dashboard');
 export const noWorkspaceOpen = vscode.l10n.t('No workspace is open. Please open a folder or workspace before running this command.');

--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -258,6 +258,77 @@ suite('AspireAppHostTreeProvider', () => {
             'samples/Store/AppHost.csproj',
         ]);
     });
+
+    test('open dashboard continues to use the external browser flow', async () => {
+        const provider = makeTreeProvider([
+            makeAppHost({
+                dashboardUrl: 'http://localhost:1001',
+            }),
+        ]);
+        const openExternalStub = sandbox.stub(vscode.env, 'openExternal').resolves(true);
+        const executeCommandStub = sandbox.stub(vscode.commands, 'executeCommand').resolves(undefined);
+
+        await provider.openDashboard();
+
+        sinon.assert.calledOnce(openExternalStub);
+        assert.strictEqual(openExternalStub.getCall(0).args[0].toString(true), 'http://localhost:1001/');
+        sinon.assert.notCalled(executeCommandStub);
+        provider.dispose();
+    });
+
+    test('open dashboard to the side uses the integrated browser beside the active editor when available', async () => {
+        const provider = makeTreeProvider([
+            makeAppHost({
+                dashboardUrl: 'http://localhost:1001',
+            }),
+        ]);
+        const openExternalStub = sandbox.stub(vscode.env, 'openExternal').resolves(true);
+        sandbox.stub(vscode.commands, 'getCommands').resolves(['workbench.action.browser.open']);
+        const executeCommandStub = sandbox.stub(vscode.commands, 'executeCommand').resolves(undefined);
+
+        await provider.openDashboardToSide();
+
+        sinon.assert.calledOnce(executeCommandStub);
+        assert.strictEqual(executeCommandStub.getCall(0).args[0], 'workbench.action.browser.open');
+        assert.deepStrictEqual(executeCommandStub.getCall(0).args[1], { url: 'http://localhost:1001', openToSide: true });
+        assert.strictEqual(executeCommandStub.getCall(0).args.length, 2);
+        sinon.assert.notCalled(openExternalStub);
+        provider.dispose();
+    });
+
+    test('open dashboard to the side falls back to simple browser placement options', async () => {
+        const provider = makeTreeProvider([
+            makeAppHost({
+                dashboardUrl: 'http://localhost:1001',
+            }),
+        ]);
+        const openExternalStub = sandbox.stub(vscode.env, 'openExternal').resolves(true);
+        sandbox.stub(vscode.commands, 'getCommands').resolves([]);
+        const executeCommandStub = sandbox.stub(vscode.commands, 'executeCommand').resolves(undefined);
+
+        await provider.openDashboardToSide();
+
+        sinon.assert.calledOnce(executeCommandStub);
+        assert.strictEqual(executeCommandStub.getCall(0).args[0], 'simpleBrowser.api.open');
+        assert.strictEqual((executeCommandStub.getCall(0).args[1] as vscode.Uri).toString(true), 'http://localhost:1001/');
+        assert.deepStrictEqual(executeCommandStub.getCall(0).args[2], { viewColumn: vscode.ViewColumn.Beside });
+        sinon.assert.notCalled(openExternalStub);
+        provider.dispose();
+    });
+
+    test('open dashboard to the side does nothing when no dashboard is available', async () => {
+        const provider = makeTreeProvider([]);
+        const openExternalStub = sandbox.stub(vscode.env, 'openExternal').resolves(true);
+        const getCommandsStub = sandbox.stub(vscode.commands, 'getCommands').resolves(['workbench.action.browser.open']);
+        const executeCommandStub = sandbox.stub(vscode.commands, 'executeCommand').resolves(undefined);
+
+        await provider.openDashboardToSide();
+
+        sinon.assert.notCalled(openExternalStub);
+        sinon.assert.notCalled(getCommandsStub);
+        sinon.assert.notCalled(executeCommandStub);
+        provider.dispose();
+    });
 });
 
 suite('AppHostDataRepository', () => {

--- a/extension/src/test/packageManifest.test.ts
+++ b/extension/src/test/packageManifest.test.ts
@@ -7,6 +7,12 @@ type ManifestMenuItem = {
     when?: string;
 };
 
+type CommandContribution = {
+    command?: string;
+    title?: string;
+    category?: string;
+};
+
 type DebuggerProperty = {
     type?: string | string[];
     description?: string;
@@ -26,8 +32,10 @@ type DebuggerContribution = {
 
 type ExtensionManifest = {
     contributes: {
+        commands?: CommandContribution[];
         viewsWelcome?: Array<{ view?: string; contents?: string; when?: string }>;
         menus?: {
+            commandPalette?: ManifestMenuItem[];
             'view/title'?: ManifestMenuItem[];
         };
         debuggers?: DebuggerContribution[];
@@ -37,6 +45,11 @@ type ExtensionManifest = {
 function readManifest(): ExtensionManifest {
     const manifestPath = path.resolve(__dirname, '../../package.json');
     return JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as ExtensionManifest;
+}
+
+function readPackageNls(): Record<string, string> {
+    const packageNlsPath = path.resolve(__dirname, '../../package.nls.json');
+    return JSON.parse(fs.readFileSync(packageNlsPath, 'utf8')) as Record<string, string>;
 }
 
 function assertContains(whenClause: string | undefined, fragment: string): void {
@@ -94,5 +107,25 @@ suite('extension/package.json', () => {
         assert.strictEqual(argsProperty.type, 'array');
         assert.strictEqual(argsProperty.items?.type, 'string');
         assert.strictEqual(argsProperty.description, '%extension.debug.args%');
+    });
+
+    test('open dashboard to the side command is contributed and localized', () => {
+        const manifest = readManifest();
+        const packageNls = readPackageNls();
+
+        const command = manifest.contributes.commands?.find(c => c.command === 'aspire-vscode.openDashboardToSide');
+        assert.ok(command, 'Expected the side-by-side dashboard command to be contributed');
+        assert.strictEqual(command.title, '%command.openDashboardToSide%');
+        assert.strictEqual(command.category, 'Aspire');
+        assert.strictEqual(packageNls['command.openDashboardToSide'], 'Open Aspire Dashboard to the Side');
+    });
+
+    test('open dashboard to the side command palette item is visible when AppHosts are running', () => {
+        const manifest = readManifest();
+        const commandPalette = manifest.contributes.menus?.commandPalette ?? [];
+
+        const command = commandPalette.find(c => c.command === 'aspire-vscode.openDashboardToSide');
+        assert.ok(command, 'Expected the side-by-side dashboard command in the command palette');
+        assert.strictEqual(command.when, '!aspire.noRunningAppHosts');
     });
 });

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -616,6 +616,28 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
     }
 
     async openDashboard(element?: TreeElement): Promise<void> {
+        const url = await this._resolveDashboardUrl(element);
+        if (url) {
+            await vscode.env.openExternal(vscode.Uri.parse(url));
+        }
+    }
+
+    async openDashboardToSide(element?: TreeElement): Promise<void> {
+        const url = await this._resolveDashboardUrl(element);
+        if (url) {
+            const commands = await vscode.commands.getCommands(true);
+            if (commands.includes('workbench.action.browser.open')) {
+                // Newer VS Code builds route Simple Browser through the integrated browser,
+                // which ignores Simple Browser placement options. Use the native side hint when available.
+                await vscode.commands.executeCommand('workbench.action.browser.open', { url, openToSide: true });
+                return;
+            }
+
+            await vscode.commands.executeCommand('simpleBrowser.api.open', vscode.Uri.parse(url), { viewColumn: vscode.ViewColumn.Beside });
+        }
+    }
+
+    private async _resolveDashboardUrl(element?: TreeElement): Promise<string | null> {
         let url: string | null = null;
 
         if (element instanceof AppHostItem) {
@@ -646,16 +668,14 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
                         placeHolder: selectDashboardPlaceholder,
                     });
                     if (!selected) {
-                        return;
+                        return null;
                     }
                     url = selected.dashboardUrl;
                 }
             }
         }
 
-        if (url) {
-            vscode.env.openExternal(vscode.Uri.parse(url));
-        }
+        return url;
     }
 
     stopAppHost(element: AppHostItem): void {


### PR DESCRIPTION
## Description

Fixes microsoft/aspire#16815.

The VS Code extension could open a running Aspire dashboard, but the command always used the existing external-browser flow. Users on wide displays had to manually move the dashboard beside their code after opening it.

### User-facing usage

Users can now run **Aspire: Open Aspire Dashboard to the Side** from the Command Palette while an AppHost is running. The existing **Aspire: Open Aspire Dashboard** command is unchanged and still uses the external-browser flow.

### How I reproduced the original issue

Environment/setup:

- VS Code Insiders or VS Code extension test host.
- An Aspire workspace with a running AppHost so the extension has a dashboard URL.
- Command Palette access to the Aspire extension commands.

Manual repro path for the feature gap:

1. Start an AppHost from the Aspire workspace.
2. Open the Command Palette and search for Aspire dashboard commands.
3. Before the fix, **Aspire: Open Aspire Dashboard** exists, but there is no command to open the dashboard beside the editor.
4. Run the existing dashboard command; it uses the external-browser flow, so users must manually arrange the dashboard side-by-side with code.

Automated repro used for the fix:

- Package-manifest tests verify the new command contribution exists with the expected localized title.
- Tree-provider command tests exercise dashboard URL resolution and verify the side-by-side VS Code browser command path is invoked.
- The same tests cover no-dashboard behavior so the new command stays aligned with the existing dashboard command.

### Fix details

- Adds the `aspire-vscode.openDashboardToSide` command contribution and registration.
- Reuses the existing dashboard URL resolution path for workspace/global AppHosts and multi-AppHost quick pick behavior.
- Opens side-by-side with the current VS Code integrated browser command when available, with a Simple Browser placement fallback for older VS Code builds.
- Keeps no-dashboard behavior as a no-op, matching the existing command.

### Tests

- `npm test -- --reporter dot` from `extension/` — 480 passing.
- Focused VS Code stable command tests: `npm run unit-test -- --grep 'open dashboard' --run out/test/appHostTreeView.test.js --run out/test/packageManifest.test.js --reporter dot` — 6 passing.
- VS Code Insiders smoke equivalent: `npm run unit-test -- --code-version insiders --grep 'open dashboard' --run out/test/appHostTreeView.test.js --run out/test/packageManifest.test.js --reporter dot` — 6 passing.

### Manual testing

VS Code Insiders and the VS Code test runner were available; Playwright CLI was not installed as a standalone command. I smoke-tested command registration and side-by-side command behavior through the VS Code Insiders extension test host rather than a manual command-palette recording.

### Local review / dogfood

Ran a local code-review pass over the diff; the only actionable finding was adding the localized string to `extension/src/loc/strings.ts`, which is included. There was no PR comment to run a repo-specific PR-testing workflow against, so the local PR-testing equivalent is the extension build/lint/unit validation above.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
