### PR TITLE
Fix dashboard browser token auth over HTTP

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -63,6 +63,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
     public const int ExitCodeAddressInUse = DashboardExitCodes.AddressInUse;
 
     private const string DashboardAuthCookieName = ".Aspire.Dashboard.Auth";
+    private const string DashboardUnsecuredTransportAuthCookieName = ".Aspire.Dashboard.Auth.UnsecuredTransport";
     private const string DashboardAntiForgeryCookieName = ".Aspire.Dashboard.Antiforgery";
     private readonly WebApplication _app;
     private readonly ILogger<DashboardWebApplication> _logger;
@@ -838,6 +839,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                 });
                 break;
             case FrontendAuthMode.BrowserToken:
+                var useUnsecuredTransportCookie = ShouldUseUnsecuredTransportBrowserTokenCookie(builder.Configuration, dashboardOptions);
                 authentication.AddPolicyScheme(FrontendAuthenticationDefaults.AuthenticationSchemeBrowserToken, displayName: FrontendAuthenticationDefaults.AuthenticationSchemeBrowserToken, o =>
                 {
                     o.ForwardDefault = CookieAuthenticationDefaults.AuthenticationScheme;
@@ -856,7 +858,19 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                         claimsIdentity.AddClaim(new Claim(FrontendAuthorizationDefaults.BrowserTokenClaimName, bool.TrueString));
                         return Task.CompletedTask;
                     };
-                    options.Cookie.Name = DashboardAuthCookieName;
+                    if (useUnsecuredTransportCookie)
+                    {
+                        // ASPIRE_ALLOW_UNSECURED_TRANSPORT explicitly permits dashboard browser access over HTTP.
+                        // Safari keeps a Secure HTTPS cookie with the same name and can ignore the HTTP sign-in
+                        // cookie, causing a login loop. Use a separate non-Secure cookie only for this explicit
+                        // mixed HTTP/HTTPS mode so normal HTTPS browser-token cookies stay Secure.
+                        options.Cookie.Name = DashboardUnsecuredTransportAuthCookieName;
+                        options.Cookie.SecurePolicy = CookieSecurePolicy.None;
+                    }
+                    else
+                    {
+                        options.Cookie.Name = DashboardAuthCookieName;
+                    }
                 });
                 break;
             case FrontendAuthMode.Unsecured:
@@ -916,6 +930,12 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                 _ => CookieAuthenticationDefaults.AuthenticationScheme
             };
         }
+    }
+
+    private static bool ShouldUseUnsecuredTransportBrowserTokenCookie(IConfiguration configuration, DashboardOptions dashboardOptions)
+    {
+        return configuration.GetBool(KnownConfigNames.AllowUnsecuredTransport) == true
+            && dashboardOptions.Frontend.GetEndpointAddresses().Any(address => string.Equals(address.Scheme, "http", StringComparison.Ordinal));
     }
 
     internal static Action<OpenIdConnectOptions> GetOidcClaimActionConfigure(ClaimAction action)

--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -541,6 +541,11 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
 
         PopulateDashboardUrls(context);
 
+        if (configuration.GetBool(KnownConfigNames.AllowUnsecuredTransport) == true)
+        {
+            context.EnvironmentVariables[KnownConfigNames.AllowUnsecuredTransport] = "true";
+        }
+
         if (options.OtlpHttpEndpointUrl != null)
         {
             // Use explicitly defined allowed origins if configured.

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -76,6 +76,80 @@ public class FrontendBrowserTokenAuthTests
     }
 
     [Fact]
+    public async Task Get_LoginPage_ValidToken_MixedHttpHttpsWithUnsecuredTransport_HttpEndpointAcceptsHttpsLoginCookie()
+    {
+        var apiKey = "TestKey123!";
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, config =>
+        {
+            config[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "https://127.0.0.1:0;http://127.0.0.1:0";
+            config[KnownConfigNames.AllowUnsecuredTransport] = "true";
+            config[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = FrontendAuthMode.BrowserToken.ToString();
+            config[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey] = apiKey;
+        });
+        await app.StartAsync().DefaultTimeout();
+
+        var httpsEndpoint = GetFrontendEndpoint(app, "https");
+        var httpEndpoint = GetFrontendEndpoint(app, "http");
+        using var client = CreateCookieClient();
+
+        var loginResponse = await client.GetAsync(httpsEndpoint + DashboardUrls.LoginUrl(token: apiKey)).DefaultTimeout();
+        Assert.Equal(HttpStatusCode.Redirect, loginResponse.StatusCode);
+
+        var response = await client.GetAsync(httpEndpoint + DashboardUrls.StructuredLogsUrl()).DefaultTimeout();
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("http")]
+    [InlineData("https")]
+    public async Task Get_LoginPage_ValidToken_UnsecuredTransport_IssuesInsecureCookieForConfiguredFrontendEndpoints(string scheme)
+    {
+        var apiKey = "TestKey123!";
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, config =>
+        {
+            config[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "https://127.0.0.1:0;http://127.0.0.1:0";
+            config[KnownConfigNames.AllowUnsecuredTransport] = "true";
+            config[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = FrontendAuthMode.BrowserToken.ToString();
+            config[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey] = apiKey;
+        });
+        await app.StartAsync().DefaultTimeout();
+
+        var endpoint = GetFrontendEndpoint(app, scheme);
+        using var client = CreateCookieClient();
+
+        var response = await client.GetAsync(endpoint + DashboardUrls.LoginUrl(token: apiKey)).DefaultTimeout();
+
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        var setCookie = GetAuthCookie(response);
+        Assert.StartsWith(".Aspire.Dashboard.Auth.UnsecuredTransport=", setCookie, StringComparison.Ordinal);
+        Assert.DoesNotContain("; secure", setCookie, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Get_LoginPage_ValidToken_HttpsEndpointWithoutUnsecuredTransport_IssuesSecureCookie()
+    {
+        var apiKey = "TestKey123!";
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, config =>
+        {
+            config[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "https://127.0.0.1:0";
+            config[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = FrontendAuthMode.BrowserToken.ToString();
+            config[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey] = apiKey;
+        });
+        await app.StartAsync().DefaultTimeout();
+
+        var endpoint = GetFrontendEndpoint(app, "https");
+        using var client = CreateCookieClient();
+
+        var response = await client.GetAsync(endpoint + DashboardUrls.LoginUrl(token: apiKey)).DefaultTimeout();
+
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        var setCookie = GetAuthCookie(response);
+        Assert.StartsWith(".Aspire.Dashboard.Auth=", setCookie, StringComparison.Ordinal);
+        Assert.DoesNotContain(".Aspire.Dashboard.Auth.UnsecuredTransport=", setCookie, StringComparison.Ordinal);
+        Assert.Contains("; secure", setCookie, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task Get_LoginPage_ValidToken_OtlpHttpConnection_Denied()
     {
         // Arrange
@@ -268,5 +342,32 @@ public class FrontendBrowserTokenAuthTests
         var summaryLog = l.Single(w => ((string?)LogTestHelpers.GetValue(w, "{OriginalFormat}"))?.StartsWith("Aspire Dashboard") == true);
         var containerMessage = "URLs may need changes depending on how network access to the container is configured.";
         Assert.Contains(containerMessage, summaryLog.Message);
+    }
+
+    private static string GetFrontendEndpoint(DashboardWebApplication app, string scheme)
+    {
+        return app.FrontendEndPointsAccessor
+            .Select(a => a())
+            .Single(e => string.Equals(e.BindingAddress.Scheme, scheme, StringComparison.OrdinalIgnoreCase))
+            .GetResolvedAddress();
+    }
+
+    private static HttpClient CreateCookieClient()
+    {
+        return new HttpClient(new SocketsHttpHandler
+        {
+            AllowAutoRedirect = false,
+            CookieContainer = new CookieContainer(),
+            SslOptions =
+            {
+                RemoteCertificateValidationCallback = (_, _, _, _) => true
+            }
+        });
+    }
+
+    private static string GetAuthCookie(HttpResponseMessage response)
+    {
+        Assert.True(response.Headers.TryGetValues("Set-Cookie", out var values));
+        return Assert.Single(values, value => value.StartsWith(".Aspire.Dashboard.Auth", StringComparison.Ordinal));
     }
 }

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
@@ -189,6 +189,33 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
         Assert.Equal("true", envVars.Single(e => e.Key == "ASPIRE_DASHBOARD_PURPLE_MONKEY_DISHWASHER").Value);
     }
 
+    [Fact]
+    public async Task ConfigureEnvironmentVariables_AllowUnsecuredTransport_CopiedToDashboard()
+    {
+        var resourceLoggerService = new ResourceLoggerService();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [KnownConfigNames.AllowUnsecuredTransport] = "true"
+            })
+            .Build();
+        var dashboardOptions = Options.Create(new DashboardOptions
+        {
+            DashboardPath = "test.dll",
+            DashboardUrl = "http://localhost:8080",
+            OtlpGrpcEndpointUrl = "http://localhost:4317",
+        });
+        var hook = CreateHook(resourceLoggerService, resourceNotificationService, configuration, dashboardOptions: dashboardOptions);
+
+        var envVars = new Dictionary<string, object>();
+        var dashboardResource = new ExecutableResource("aspire-dashboard", "dashboard.exe", ".");
+
+        await hook.ConfigureEnvironmentVariables(new EnvironmentCallbackContext(new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run), environmentVariables: envVars, resource: dashboardResource));
+
+        Assert.Equal("true", envVars.Single(e => e.Key == KnownConfigNames.AllowUnsecuredTransport).Value);
+    }
+
     [Theory]
     [InlineData("https://localhost:17131", "localhost", 9999, "https")]
     [InlineData("https://aspire-dashboard.dev.localhost:17131", "aspire-dashboard.dev.localhost", 9999, "https")]


### PR DESCRIPTION
## Description

Fixes microsoft/aspire#16067.

Browser token auth over HTTP could get stuck in a login loop when the browser already had the normal Secure dashboard auth cookie for the same localhost host. This change propagates the explicit unsecured-transport opt-in to the dashboard process and uses a separate non-Secure cookie only for browser-token auth over an HTTP dashboard frontend.

### How I reproduced the original issue

Environment/setup:

- macOS with Safari, matching the reporter's browser where the cookie conflict was observed.
- An Aspire AppHost/dashboard with both HTTPS and HTTP dashboard frontend URLs on the same localhost host.
- Browser-token auth enabled with a known token and unsecured transport explicitly enabled.
- Example launch settings shape from the issue:

   ```json
   {
     "applicationUrl": "https://localhost:15233;http://localhost:15234",
     "environmentVariables": {
       "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
       "ASPIRE_DASHBOARD_FRONTEND_BROWSERTOKEN": "token"
     }
   }
   ```

Manual repro path:

1. Run the AppHost/dashboard with the mixed HTTPS/HTTP frontend setup above.
2. In Safari, navigate to the HTTPS login URL first, for example `https://localhost:15233/login?t=token`, and confirm the dashboard loads. This seeds the normal Secure dashboard auth cookie.
3. Navigate to the HTTP login URL for the same dashboard, for example `http://localhost:15234/login?t=token`.
4. Before the fix, the server logs a cookie sign-in, but authorization immediately fails with a missing `BrowserTokenClaim`, and the browser is redirected back to the token prompt in a loop.
5. The key signal is that the HTTP navigation cannot use the existing Secure dashboard auth cookie that was created by the HTTPS navigation.

Validation repro used for the fix:

- Dashboard auth tests cover unsecured browser-token options and cookie naming/Secure policy behavior.
- Hosting tests cover propagation of `ASPIRE_ALLOW_UNSECURED_TRANSPORT` from the AppHost to the dashboard process.
- Manual smoke confirmed a mixed HTTPS/HTTP dashboard with browser-token auth can access HTTP dashboard pages after login when unsecured transport is explicitly enabled.

### Root cause analysis

Safari can keep a previously-created Secure dashboard auth cookie for localhost. When the dashboard is later used over HTTP with the same cookie name, the browser-token login succeeds server-side but the HTTP navigation cannot use/replace the Secure cookie, so authorization sees no `BrowserTokenClaim` and redirects back to login.

### Why this fix

`ASPIRE_ALLOW_UNSECURED_TRANSPORT=true` explicitly permits dashboard browser access over HTTP, but the dashboard process did not receive that AppHost setting and always used the standard auth cookie name/Secure behavior.

### Fix details

- Propagate `ASPIRE_ALLOW_UNSECURED_TRANSPORT=true` from AppHost to the dashboard process.
- When browser-token auth is explicitly running with unsecured transport and an HTTP frontend endpoint exists, use a separate `.Aspire.Dashboard.Auth.UnsecuredTransport` cookie with `SecurePolicy=None`.
- Preserve the normal `.Aspire.Dashboard.Auth` Secure cookie for HTTPS-only configurations.

### Security considerations

This change only relaxes the dashboard auth cookie `Secure` policy when the existing `ASPIRE_ALLOW_UNSECURED_TRANSPORT=true` opt-in is present and an HTTP dashboard frontend endpoint exists. HTTPS-only browser-token auth continues to use the original Secure cookie name and policy.

### Tests

- `dotnet test --project tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.DashboardEventHandlersTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

### Manual testing / security

- Smoke-tested dashboard with mixed HTTPS/HTTP frontend endpoints, browser-token auth, and `ASPIRE_ALLOW_UNSECURED_TRANSPORT=true`: HTTPS `/login?t=token` issued the unsecured-transport cookie without `Secure`, and HTTP `/structuredlogs` returned 200 using that cookie.
- HTTPS-only browser-token auth remains on the original Secure auth cookie.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
