### PR TITLE
Fix VS Code CLI update fallback

### DIFF
--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -497,7 +497,7 @@
       <source xml:lang="en">The Aspire CLI creates, runs, and manages your applications. Install it using the commands in the panel, then verify your installation.&#10;&#10;[Verify installation](command:aspire-vscode.verifyCliInstalled)</source>
     </trans-unit>
     <trans-unit id="views.runningAppHosts.errorWelcome">
-      <source xml:lang="en">The Aspire CLI is not installed or does not support this feature. Install or update the Aspire CLI and restart VS Code to get started.&#10;[Update Aspire CLI](command:aspire-vscode.updateSelf)&#10;[Refresh](command:aspire-vscode.refreshRunningAppHosts)</source>
+      <source xml:lang="en">The Aspire CLI is unavailable to the extension or does not support this feature. Install or update the Aspire CLI, then refresh this view to get started.&#10;[Update Aspire CLI](command:aspire-vscode.installCliDaily)&#10;[Refresh](command:aspire-vscode.refreshRunningAppHosts)</source>
     </trans-unit>
     <trans-unit id="walkthrough.getStarted.dashboard.description">
       <source xml:lang="en">The Aspire Dashboard shows your resources, endpoints, logs, traces, and metrics — all in one place.&#10;&#10;[Open dashboard](command:aspire-vscode.openDashboard)</source>

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -136,7 +136,7 @@
   "views.runningAppHosts.loading": "Searching for running AppHosts...",
   "views.runningAppHosts.welcome": "No running Aspire AppHost detected in this workspace.\n[Refresh](command:aspire-vscode.refreshRunningAppHosts)",
   "views.runningAppHosts.globalWelcome": "No running Aspire AppHosts detected on this machine.\n[Refresh](command:aspire-vscode.refreshRunningAppHosts)",
-  "views.runningAppHosts.errorWelcome": "The Aspire CLI is not installed or does not support this feature. Install or update the Aspire CLI and restart VS Code to get started.\n[Update Aspire CLI](command:aspire-vscode.updateSelf)\n[Refresh](command:aspire-vscode.refreshRunningAppHosts)",
+  "views.runningAppHosts.errorWelcome": "The Aspire CLI is unavailable to the extension or does not support this feature. Install or update the Aspire CLI, then refresh this view to get started.\n[Update Aspire CLI](command:aspire-vscode.installCliDaily)\n[Refresh](command:aspire-vscode.refreshRunningAppHosts)",
   "command.refreshRunningAppHosts": "Refresh running AppHosts",
   "command.openDashboard": "Open Aspire Dashboard",
   "command.openAppHostSource": "Open AppHost source",

--- a/extension/src/commands/update.ts
+++ b/extension/src/commands/update.ts
@@ -1,12 +1,16 @@
 import { AspireEditorCommandProvider } from '../editor/AspireEditorCommandProvider';
 import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
 import { getAppHostArgs } from '../utils/appHostArgs';
+import { runCliInstallCommand } from './walkthroughCommands';
 
 export async function updateCommand(terminalProvider: AspireTerminalProvider, editorCommandProvider: AspireEditorCommandProvider) {
     const appHostArgs = await getAppHostArgs(editorCommandProvider);
     await terminalProvider.sendAspireCommandToAspireTerminal('update', true, appHostArgs);
 }
 
-export async function updateSelfCommand(terminalProvider: AspireTerminalProvider) {
-    await terminalProvider.sendAspireCommandToAspireTerminal('update --self');
+export async function updateSelfCommand(_terminalProvider: AspireTerminalProvider) {
+    // The panel shows this action when the installed CLI may be too old to
+    // understand `aspire update --self`, so use the acquisition script instead
+    // of routing through the current CLI.
+    runCliInstallCommand('daily');
 }

--- a/extension/src/commands/walkthroughCommands.ts
+++ b/extension/src/commands/walkthroughCommands.ts
@@ -1,6 +1,23 @@
 import * as vscode from 'vscode';
 import { aspireTerminalName } from '../loc/strings';
 
+export type CliInstallQuality = 'stable' | 'daily';
+
+export function getCliInstallCommand(quality: CliInstallQuality, platform: NodeJS.Platform = process.platform): string {
+    if (platform === 'win32') {
+        // The command is sent to the user's configured terminal profile. Invoke
+        // Windows PowerShell explicitly so the installer also works when the
+        // default profile is Command Prompt instead of PowerShell.
+        return quality === 'daily'
+            ? 'powershell -NoProfile -ExecutionPolicy Bypass -Command "& ([scriptblock]::Create((irm \'https://aspire.dev/install.ps1\'))) -Quality dev"'
+            : 'powershell -NoProfile -ExecutionPolicy Bypass -Command "irm \'https://aspire.dev/install.ps1\' | iex"';
+    }
+
+    return quality === 'daily'
+        ? 'curl -sSL https://aspire.dev/install.sh | bash -s -- -q dev'
+        : 'curl -sSL https://aspire.dev/install.sh | bash';
+}
+
 function getOrCreateTerminal(): vscode.Terminal {
     const existing = vscode.window.terminals.find(t => t.name === aspireTerminalName);
     if (existing) {
@@ -15,20 +32,16 @@ function runInTerminal(command: string): void {
     terminal.sendText(command);
 }
 
+export function runCliInstallCommand(quality: CliInstallQuality): void {
+    runInTerminal(getCliInstallCommand(quality));
+}
+
 export async function installCliStableCommand(): Promise<void> {
-    if (process.platform === 'win32') {
-        runInTerminal('irm https://aspire.dev/install.ps1 | iex');
-    } else {
-        runInTerminal('curl -sSL https://aspire.dev/install.sh | bash');
-    }
+    runCliInstallCommand('stable');
 }
 
 export async function installCliDailyCommand(): Promise<void> {
-    if (process.platform === 'win32') {
-        runInTerminal('iex "& { $(irm https://aspire.dev/install.ps1) } -Quality dev"');
-    } else {
-        runInTerminal('curl -sSL https://aspire.dev/install.sh | bash -s -- -q dev');
-    }
+    runCliInstallCommand('daily');
 }
 
 export async function verifyCliInstalledCommand(): Promise<void> {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -40,6 +40,16 @@ import { ResourceCommandJson } from './views/AppHostDataRepository';
 
 let aspireExtensionContext = new AspireExtensionContext();
 
+const cliCheckExcludedCommands = new Set([
+  'aspire-vscode.settings',
+  'aspire-vscode.configureLaunchJson',
+  'aspire-vscode.updateSelf',
+]);
+
+export function commandRequiresCliAvailability(commandName: string): boolean {
+  return !cliCheckExcludedCommands.has(commandName);
+}
+
 export async function activate(context: vscode.ExtensionContext) {
   const gitCommitSha = readGitCommitSha(context);
   extensionLogOutputChannel.info(`Activating Aspire extension (commit: ${gitCommitSha})`);
@@ -252,9 +262,7 @@ async function tryExecuteCommand(commandName: string, terminalProvider: AspireTe
   try {
     sendTelemetryEvent(`${commandName}.invoked`);
 
-    const cliCheckExcludedCommands: string[] = ["aspire-vscode.settings", "aspire-vscode.configureLaunchJson"];
-
-    if (!cliCheckExcludedCommands.includes(commandName)) {
+    if (commandRequiresCliAvailability(commandName)) {
       const result = await checkCliAvailableOrRedirect();
       if (!result.available) {
         return;

--- a/extension/src/test/extension.test.ts
+++ b/extension/src/test/extension.test.ts
@@ -1,0 +1,12 @@
+import * as assert from 'assert';
+import { commandRequiresCliAvailability } from '../extension';
+
+suite('extension command registration', () => {
+    test('updateSelf does not require an already usable CLI', () => {
+        assert.strictEqual(commandRequiresCliAvailability('aspire-vscode.updateSelf'), false);
+    });
+
+    test('regular CLI commands still require CLI availability', () => {
+        assert.strictEqual(commandRequiresCliAvailability('aspire-vscode.add'), true);
+    });
+});

--- a/extension/src/test/packageManifest.test.ts
+++ b/extension/src/test/packageManifest.test.ts
@@ -34,9 +34,16 @@ type ExtensionManifest = {
     };
 };
 
+type PackageNls = Record<string, string>;
+
 function readManifest(): ExtensionManifest {
     const manifestPath = path.resolve(__dirname, '../../package.json');
     return JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as ExtensionManifest;
+}
+
+function readPackageNls(): PackageNls {
+    const packageNlsPath = path.resolve(__dirname, '../../package.nls.json');
+    return JSON.parse(fs.readFileSync(packageNlsPath, 'utf8')) as PackageNls;
 }
 
 function assertContains(whenClause: string | undefined, fragment: string): void {
@@ -94,5 +101,14 @@ suite('extension/package.json', () => {
         assert.strictEqual(argsProperty.type, 'array');
         assert.strictEqual(argsProperty.items?.type, 'string');
         assert.strictEqual(argsProperty.description, '%extension.debug.args%');
+    });
+
+    test('running apphosts error welcome updates CLI with installer command that does not depend on current CLI support', () => {
+        const packageNls = readPackageNls();
+        const errorWelcome = packageNls['views.runningAppHosts.errorWelcome'];
+
+        assert.ok(!errorWelcome.includes('not installed'), `Error welcome should not report the CLI as not installed when it may only be unavailable to VS Code or too old: ${errorWelcome}`);
+        assert.ok(errorWelcome.includes('(command:aspire-vscode.installCliDaily)'), `Expected error welcome to link to the daily installer command: ${errorWelcome}`);
+        assert.ok(!errorWelcome.includes('(command:aspire-vscode.updateSelf)'), `Error welcome must not use updateSelf because old CLIs may not support self update: ${errorWelcome}`);
     });
 });

--- a/extension/src/test/update.test.ts
+++ b/extension/src/test/update.test.ts
@@ -1,0 +1,37 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { updateSelfCommand } from '../commands/update';
+import { getCliInstallCommand } from '../commands/walkthroughCommands';
+import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
+import { aspireTerminalName } from '../loc/strings';
+
+suite('commands/update', () => {
+    test('updateSelfCommand uses installer instead of requiring the installed CLI to support self update', async () => {
+        const sentTexts: string[] = [];
+        let shown = false;
+        const terminal = {
+            name: aspireTerminalName,
+            show: () => { shown = true; },
+            sendText: (text: string) => { sentTexts.push(text); },
+        } as unknown as vscode.Terminal;
+        const terminalsStub = sinon.stub(vscode.window, 'terminals').value([]);
+        const createTerminalStub = sinon.stub(vscode.window, 'createTerminal').returns(terminal);
+        const terminalProvider = {
+            sendAspireCommandToAspireTerminal: sinon.stub().resolves(),
+        } as unknown as AspireTerminalProvider;
+
+        try {
+            await updateSelfCommand(terminalProvider);
+
+            assert.strictEqual(shown, true);
+            assert.deepStrictEqual(sentTexts, [getCliInstallCommand('daily')]);
+            assert.strictEqual((terminalProvider.sendAspireCommandToAspireTerminal as sinon.SinonStub).called, false);
+            assert.strictEqual(createTerminalStub.calledOnce, true);
+        }
+        finally {
+            terminalsStub.restore();
+            createTerminalStub.restore();
+        }
+    });
+});

--- a/extension/src/test/walkthroughCommands.test.ts
+++ b/extension/src/test/walkthroughCommands.test.ts
@@ -1,0 +1,22 @@
+import * as assert from 'assert';
+import { getCliInstallCommand } from '../commands/walkthroughCommands';
+
+suite('walkthroughCommands', () => {
+    suite('getCliInstallCommand', () => {
+        test('returns Windows PowerShell stable installer command', () => {
+            assert.strictEqual(getCliInstallCommand('stable', 'win32'), 'powershell -NoProfile -ExecutionPolicy Bypass -Command "irm \'https://aspire.dev/install.ps1\' | iex"');
+        });
+
+        test('returns Windows PowerShell daily installer command', () => {
+            assert.strictEqual(getCliInstallCommand('daily', 'win32'), 'powershell -NoProfile -ExecutionPolicy Bypass -Command "& ([scriptblock]::Create((irm \'https://aspire.dev/install.ps1\'))) -Quality dev"');
+        });
+
+        test('returns Unix stable installer command', () => {
+            assert.strictEqual(getCliInstallCommand('stable', 'linux'), 'curl -sSL https://aspire.dev/install.sh | bash');
+        });
+
+        test('returns Unix daily installer command', () => {
+            assert.strictEqual(getCliInstallCommand('daily', 'darwin'), 'curl -sSL https://aspire.dev/install.sh | bash -s -- -q dev');
+        });
+    });
+});


### PR DESCRIPTION
## Description

Fixes microsoft/aspire#15363.

This updates the Aspire panel unsupported/unavailable CLI recovery path so it no longer reports the CLI as definitively not installed when the real problem may be an unavailable or too-old CLI. The panel's **Update Aspire CLI** action now uses the daily acquisition installer instead of requiring the currently installed CLI to support `aspire update --self`, and Windows installer commands explicitly invoke PowerShell so they work from cmd-default VS Code terminals.

### User-facing usage

When the Aspire extension cannot use the installed CLI, the panel update action now opens the existing Aspire terminal and runs the daily installer command directly. Users do not need the currently installed `aspire` binary to understand self-update commands before they can recover.

### How I reproduced the original issue

Environment/setup from the report:

- Windows 10/11 with VS Code and the Aspire extension.
- An `aspire` executable on `PATH` where `aspire --version` works, but the extension treats the CLI as unavailable or unsupported for newer panel commands.
- For the Windows installer-command parsing edge case, configure the VS Code integrated terminal default profile to Command Prompt.

Manual repro path:

1. Open a workspace with the Aspire VS Code extension and click the Aspire activity-bar icon.
2. Before the fix, the panel can present the CLI as not installed/unavailable even though `aspire --version` works in a terminal.
3. Click **Update Aspire CLI** in the panel.
4. Before the fix, the update action depends on the current CLI by sending `aspire update --self`; with an old or unsupported CLI this fails, so the recovery button cannot recover the broken/unsupported CLI state.
5. With a Command Prompt default terminal, installer commands that assume PowerShell syntax can also fail to parse unless PowerShell is invoked explicitly.

Automated/local repro used for the fix:

- Extension command tests cover the panel update link and ensure the recovery command is not blocked by the normal CLI availability pre-check.
- Installer command-generation tests cover Windows stable/daily commands and Unix stable/daily commands.
- The Windows command tests verify PowerShell is invoked explicitly, which is the part needed for cmd-default terminals.
- I did not have a live Windows VS Code panel available in this macOS worktree, so the local repro evidence is from the issue report plus targeted extension tests for the failing command paths.

### Root cause analysis

The panel error state conflated an unavailable CLI with an installed-but-too-old CLI. Its update link invoked `aspire-vscode.updateSelf`, which first ran the extension CLI availability check and then sent `aspire update --self` through the installed CLI. Older CLIs can be present on PATH but not understand the self-update command or newer panel commands, so the recovery action depended on the broken/old CLI. On Windows, the installer commands also assumed a PowerShell terminal profile.

### Why this fix

The panel is a recovery path when CLI discovery or feature support fails. That path should not rely on the current CLI binary, and it should work regardless of the user's Windows terminal profile.

### Fix details

- Reuse the walkthrough installer path for CLI self-update recovery.
- Exclude `aspire-vscode.updateSelf` from the CLI availability pre-check.
- Centralize stable/daily installer command construction and cover Windows/Unix variants.
- Point the panel error welcome update link directly to the daily installer command.
- Update localized source strings/XLF.

### Security considerations

This PR changes generated terminal commands for installing/updating the Aspire CLI. It keeps using the existing official Aspire installer URLs and fixed quality values, and on Windows it explicitly invokes PowerShell so the command is parsed by the shell syntax it already uses.

### Tests

- `npm run compile-tests -- --pretty false`
- `npm run lint -- --quiet`
- `npm run compile` (passes; existing webpack optional dependency/dynamic require warnings remain)
- `vscode-test --config .vscode-test.short.mjs --reporter dot` with short user-data-dir: 482 passing

### Manual testing / smoke

- Verified `code-insiders --version` is available.
- Extension has no Playwright panel smoke harness (`extension/node_modules/.bin/playwright` absent; only RPC e2e tests exist), so panel smoke was covered by VS Code extension tests and command-generation tests.

### Local PR-testing equivalent

- Ran extension build, lint, compile-tests, and full VS Code extension test suite locally.
- No draft PR dogfood comment was available before PR creation; documented local dogfood limitation here.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
