### PR TITLE
Fix dashboard browser launch in remote VS Code sessions

### DIFF
--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -6,7 +6,7 @@ import { AspireResourceExtendedDebugConfiguration, AspireResourceDebugSession, E
 import { extensionLogOutputChannel } from "../utils/logging";
 import AspireDcpServer, { generateDcpIdPrefix } from "../dcp/AspireDcpServer";
 import { spawnCliProcess } from "./languages/cli";
-import { disconnectingFromSession, launchingWithAppHost, launchingWithDirectory, processExceptionOccurred, processExitedWithCode, aspireDashboard, appHostSessionTerminated } from "../loc/strings";
+import { disconnectingFromSession, launchingWithAppHost, launchingWithDirectory, processExceptionOccurred, processExitedWithCode, appHostSessionTerminated } from "../loc/strings";
 import { projectDebuggerExtension } from "./languages/dotnet";
 import { AnsiColors } from "../utils/AspireTerminalProvider";
 import { applyTextStyle } from "../utils/strings";
@@ -17,10 +17,10 @@ import { createDebugSessionConfiguration } from "./debuggerExtensions";
 import { AspireTerminalProvider } from "../utils/AspireTerminalProvider";
 import { ICliRpcClient } from "../server/rpcClient";
 import path from "path";
-import os from "os";
 import { EnvironmentVariables } from "../utils/environment";
+import { openDashboardInBrowser, type DashboardBrowserType } from "./dashboardBrowser";
 
-export type DashboardBrowserType = 'openExternalBrowser' | 'integratedBrowser' | 'debugChrome' | 'debugEdge' | 'debugFirefox';
+export type { DashboardBrowserType } from "./dashboardBrowser";
 
 export class AspireDebugSession implements vscode.DebugAdapter {
   private readonly _onDidSendMessage = new EventEmitter<any>();
@@ -72,14 +72,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
       });
     }
     else if (message.command === 'launch') {
-      this.sendEvent({
-        type: 'response',
-        request_seq: message.seq,
-        seq: this._messageSeq++,
-        success: true,
-        command: 'launch',
-        body: {}
-      });
+      this.sendResponse(message);
 
       const appHostPath = this._session.configuration.program as string;
       const command = this.configuration.command ?? 'run';
@@ -145,15 +138,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
       });
     }
     else if (message.command) {
-      // Respond to all other requests with a generic success
-      this.sendEvent({
-        type: 'response',
-        request_seq: message.seq,
-        seq: this._messageSeq++,
-        success: true,
-        command: message.command,
-        body: {}
-      });
+      this.sendResponse(message, createResponseBodyForRequest(message.command));
     }
 
     function isDirectory(pathToCheck: string): boolean {
@@ -431,76 +416,12 @@ export class AspireDebugSession implements vscode.DebugAdapter {
    * For debugChrome/debugEdge/debugFirefox, launches as a child debug session that auto-closes with the Aspire debug session.
    */
   async openDashboard(url: string, browserType: DashboardBrowserType): Promise<void> {
-    extensionLogOutputChannel.info(`Opening dashboard in browser: ${browserType}, URL: ${url}`);
-
-    switch (browserType) {
-      case 'debugChrome':
-        await this.launchDebugBrowser(url, 'pwa-chrome');
-        break;
-
-      case 'debugEdge':
-        await this.launchDebugBrowser(url, 'pwa-msedge');
-        break;
-
-      case 'debugFirefox':
-        await this.launchDebugBrowser(url, 'firefox');
-        break;
-
-      case 'integratedBrowser':
-        await vscode.commands.executeCommand('simpleBrowser.show', url);
-        break;
-
-      case 'openExternalBrowser':
-      default:
-        // Use VS Code's default external browser handling
-        await vscode.env.openExternal(vscode.Uri.parse(url));
-        break;
-    }
-  }
-
-  /**
-   * Launches a browser as a child debug session.
-   * The browser will automatically close when the parent Aspire debug session ends.
-   */
-  private async launchDebugBrowser(url: string, debugType: 'pwa-chrome' | 'pwa-msedge' | 'firefox'): Promise<void> {
-    const debugConfig: vscode.DebugConfiguration = {
-      type: debugType,
-      name: aspireDashboard,
-      request: 'launch',
-      url: url,
-    };
-
-    // Add type-specific options
-    if (debugType === 'pwa-chrome' || debugType === 'pwa-msedge') {
-      // Don't pause on entry for Chrome/Edge
-      debugConfig.pauseForSourceMap = false;
-    }
-    else if (debugType === 'firefox') {
-      // Firefox debugger requires webRoot; resolve to actual workspace path
-      debugConfig.webRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? os.tmpdir();
-      debugConfig.pathMappings = [];
-    }
-
-    // Register listener before starting so we don't miss the event
-    const disposable = vscode.debug.onDidStartDebugSession((session) => {
-      if (session.configuration.name === aspireDashboard && session.type === debugType) {
+    await openDashboardInBrowser(url, browserType, {
+      parentSession: this._session,
+      onDidStartDebugBrowser: (session) => {
         this._dashboardDebugSession = session;
-        disposable.dispose();
       }
     });
-
-    // Start as a child debug session - it will close when parent closes
-    const didStart = await vscode.debug.startDebugging(
-      undefined,
-      debugConfig,
-      this._session
-    );
-
-    if (!didStart) {
-      disposable.dispose();
-      extensionLogOutputChannel.warn(`Failed to start debug browser (${debugType}), falling back to default browser`);
-      await vscode.env.openExternal(vscode.Uri.parse(url));
-    }
   }
 
   dispose(): void {
@@ -584,6 +505,47 @@ export class AspireDebugSession implements vscode.DebugAdapter {
 
   notifyAppHostStartupCompleted() {
     extensionLogOutputChannel.info(`AppHost startup completed and dashboard is running.`);
+  }
+}
+
+function createResponseBodyForRequest(command: string): object {
+  // The Aspire parent debug adapter only orchestrates child sessions, but VS Code can still
+  // issue normal DAP requests to it. Return protocol-shaped empty bodies so VS Code doesn't
+  // receive successful responses with missing arrays such as `variables`.
+  switch (command) {
+    case 'breakpointLocations':
+    case 'setBreakpoints':
+      return { breakpoints: [] };
+
+    case 'completions':
+      return { targets: [] };
+
+    case 'evaluate':
+      return { result: '', variablesReference: 0 };
+
+    case 'loadedSources':
+      return { sources: [] };
+
+    case 'modules':
+      return { modules: [], totalModules: 0 };
+
+    case 'scopes':
+      return { scopes: [] };
+
+    case 'source':
+      return { content: '' };
+
+    case 'stackTrace':
+      return { stackFrames: [], totalFrames: 0 };
+
+    case 'threads':
+      return { threads: [] };
+
+    case 'variables':
+      return { variables: [] };
+
+    default:
+      return {};
   }
 }
 

--- a/extension/src/debugger/dashboardBrowser.ts
+++ b/extension/src/debugger/dashboardBrowser.ts
@@ -1,0 +1,93 @@
+import * as vscode from "vscode";
+import { aspireDashboard } from "../loc/strings";
+import { extensionLogOutputChannel } from "../utils/logging";
+
+export type DashboardBrowserType = 'openExternalBrowser' | 'integratedBrowser' | 'debugChrome' | 'debugEdge' | 'debugFirefox';
+
+type DebugBrowserType = 'pwa-chrome' | 'pwa-msedge' | 'firefox';
+
+type OpenDashboardBrowserOptions = {
+  parentSession?: vscode.DebugSession;
+  onDidStartDebugBrowser?: (session: vscode.DebugSession) => void;
+};
+
+export async function openDashboardInBrowser(url: string, browserType: DashboardBrowserType, options: OpenDashboardBrowserOptions = {}): Promise<void> {
+  extensionLogOutputChannel.info(`Opening dashboard in browser: ${browserType}, URL: ${url}`);
+
+  switch (browserType) {
+    case 'debugChrome':
+      await launchDebugBrowser(url, 'pwa-chrome', options);
+      break;
+
+    case 'debugEdge':
+      await launchDebugBrowser(url, 'pwa-msedge', options);
+      break;
+
+    case 'debugFirefox':
+      await launchDebugBrowser(url, 'firefox', options);
+      break;
+
+    case 'integratedBrowser':
+      await vscode.commands.executeCommand('simpleBrowser.show', await getClientAccessibleUrl(url));
+      break;
+
+    case 'openExternalBrowser':
+    default:
+      // VS Code automatically resolves http(s) URIs passed to openExternal for remote
+      // extension hosts, including setting up SSH port forwarding when necessary.
+      // See vscode.env.asExternalUri in @types/vscode for the documented behavior.
+      await vscode.env.openExternal(vscode.Uri.parse(url));
+      break;
+  }
+}
+
+async function launchDebugBrowser(url: string, debugType: DebugBrowserType, options: OpenDashboardBrowserOptions): Promise<void> {
+  const debugConfig: vscode.DebugConfiguration = {
+    type: debugType,
+    name: aspireDashboard,
+    request: 'launch',
+    url: await getClientAccessibleUrl(url),
+  };
+
+  if (debugType === 'pwa-chrome' || debugType === 'pwa-msedge') {
+    debugConfig.pauseForSourceMap = false;
+  }
+  else if (debugType === 'firefox') {
+    debugConfig.webRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? process.cwd();
+    debugConfig.pathMappings = [];
+  }
+
+  const disposable = vscode.debug.onDidStartDebugSession((session) => {
+    if (session.configuration.name === aspireDashboard && session.type === debugType) {
+      options.onDidStartDebugBrowser?.(session);
+      disposable.dispose();
+    }
+  });
+
+  const didStart = await vscode.debug.startDebugging(
+    undefined,
+    debugConfig,
+    options.parentSession
+  );
+
+  if (!didStart) {
+    disposable.dispose();
+    extensionLogOutputChannel.warn(`Failed to start debug browser (${debugType}), falling back to default browser`);
+    await vscode.env.openExternal(vscode.Uri.parse(url));
+  }
+}
+
+async function getClientAccessibleUrl(url: string): Promise<string> {
+  const uri = vscode.Uri.parse(url);
+  if (uri.scheme !== 'http' && uri.scheme !== 'https') {
+    return url;
+  }
+
+  try {
+    return (await vscode.env.asExternalUri(uri)).toString(true);
+  }
+  catch (err) {
+    extensionLogOutputChannel.warn(`Failed to resolve dashboard URL for external access: ${err}`);
+    return url;
+  }
+}

--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -9,7 +9,8 @@ import { applyTextStyle, formatText } from '../utils/strings';
 import { extensionLogOutputChannel } from '../utils/logging';
 import { AspireExtendedDebugConfiguration, EnvVar } from '../dcp/types';
 import { AnsiColors, AspireTerminal } from '../utils/AspireTerminalProvider';
-import { AspireDebugSession, DashboardBrowserType } from '../debugger/AspireDebugSession';
+import { AspireDebugSession } from '../debugger/AspireDebugSession';
+import { openDashboardInBrowser, type DashboardBrowserType } from '../debugger/dashboardBrowser';
 import { isDirectory } from '../utils/io';
 
 export interface IInteractionService {
@@ -361,9 +362,12 @@ export class InteractionService implements IInteractionService {
             // Open the dashboard URL in the configured browser. Prefer codespaces URL if available.
             const urlToOpen = codespacesUrl || baseUrl;
             const debugSession = this._getAspireDebugSession();
+            const browserType = aspireConfig.get<DashboardBrowserType>('dashboardBrowser', 'openExternalBrowser');
             if (debugSession) {
-                const browserType = aspireConfig.get<DashboardBrowserType>('dashboardBrowser', 'openExternalBrowser');
                 await debugSession.openDashboard(urlToOpen, browserType);
+            }
+            else {
+                await openDashboardInBrowser(urlToOpen, browserType);
             }
             return;
         }

--- a/extension/src/test/dotnetDebugger.test.ts
+++ b/extension/src/test/dotnetDebugger.test.ts
@@ -47,10 +47,106 @@ class TestDotNetService {
 suite('Dotnet Debugger Extension Tests', () => {
     teardown(() => sinon.restore());
 
+    function createParentDebugSession(): vscode.DebugSession {
+        return {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            workspaceFolder: undefined,
+            configuration: {
+                type: 'aspire',
+                request: 'launch',
+                name: 'Aspire',
+                program: '/workspace/apphost.ts'
+            },
+            customRequest: sinon.stub(),
+            getDebugProtocolBreakpoint: sinon.stub()
+        } as unknown as vscode.DebugSession;
+    }
+
     function createDebuggerExtension(outputPath: string, rejectBuild: Error | null, hasDevKit: boolean, doesOutputFileExist: boolean): { dotNetService: TestDotNetService, extension: ResourceDebuggerExtension, doesFileExistStub: sinon.SinonStub } {
         const fakeDotNetService = new TestDotNetService(outputPath, rejectBuild, hasDevKit);
         return { dotNetService: fakeDotNetService, extension: createProjectDebuggerExtension(() => fakeDotNetService), doesFileExistStub: sinon.stub(io, 'doesFileExist').resolves(doesOutputFileExist) };
     }
+
+    test('opens debug dashboard as a child of the Aspire debug session with a client-accessible URL', async () => {
+        const parentDebugSession = createParentDebugSession();
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession, {} as any, {} as any, {} as any, () => { });
+        const baseUrl = 'http://localhost:15000/login?t=abc';
+        const externalUrl = vscode.Uri.parse('http://127.0.0.1:55002/login?t=abc');
+        const dashboardDebugSession = {
+            id: 'dashboard-session',
+            type: 'pwa-msedge',
+            name: 'Aspire Dashboard',
+            workspaceFolder: undefined,
+            configuration: {
+                name: 'Aspire Dashboard'
+            },
+            customRequest: sinon.stub(),
+            getDebugProtocolBreakpoint: sinon.stub()
+        } as unknown as vscode.DebugSession;
+        let startListener: ((session: vscode.DebugSession) => void) | undefined;
+        const listenerDisposable = { dispose: sinon.stub() };
+
+        const asExternalUriStub = sinon.stub(vscode.env, 'asExternalUri').resolves(externalUrl);
+        const onDidStartDebugSessionStub = sinon.stub(vscode.debug, 'onDidStartDebugSession').callsFake((listener) => {
+            startListener = listener;
+            return listenerDisposable;
+        });
+        const startDebuggingStub = sinon.stub(vscode.debug, 'startDebugging').callsFake(async () => {
+            startListener?.(dashboardDebugSession);
+            return true;
+        });
+
+        await aspireDebugSession.openDashboard(baseUrl, 'debugEdge');
+
+        assert.strictEqual(asExternalUriStub.callCount, 1);
+        assert.strictEqual(asExternalUriStub.getCall(0).args[0].toString(true), baseUrl);
+        assert.strictEqual(onDidStartDebugSessionStub.callCount, 1);
+        assert.strictEqual(startDebuggingStub.callCount, 1);
+        assert.strictEqual(startDebuggingStub.getCall(0).args[2], parentDebugSession);
+        assert.deepStrictEqual(startDebuggingStub.getCall(0).args[1], {
+            type: 'pwa-msedge',
+            name: 'Aspire Dashboard',
+            request: 'launch',
+            url: externalUrl.toString(true),
+            pauseForSourceMap: false
+        });
+        assert.strictEqual(listenerDisposable.dispose.callCount, 1);
+    });
+
+    test('returns protocol-shaped empty bodies for Aspire parent debug adapter collection requests', () => {
+        const aspireDebugSession = new AspireDebugSession(createParentDebugSession(), {} as any, {} as any, {} as any, () => { });
+        const messages: any[] = [];
+        const outputSubscription = aspireDebugSession.onDidSendMessage(message => messages.push(message));
+
+        const requests = [
+            { command: 'variables', expectedBody: { variables: [] } },
+            { command: 'scopes', expectedBody: { scopes: [] } },
+            { command: 'stackTrace', expectedBody: { stackFrames: [], totalFrames: 0 } },
+            { command: 'threads', expectedBody: { threads: [] } }
+        ];
+
+        for (const [index, request] of requests.entries()) {
+            aspireDebugSession.handleMessage({
+                type: 'request',
+                seq: index + 1,
+                command: request.command
+            });
+        }
+
+        const responses = messages.filter(message => message.type === 'response');
+        assert.strictEqual(responses.length, requests.length);
+
+        for (const [index, request] of requests.entries()) {
+            assert.strictEqual(responses[index].request_seq, index + 1);
+            assert.strictEqual(responses[index].command, request.command);
+            assert.strictEqual(responses[index].success, true);
+            assert.deepStrictEqual(responses[index].body, request.expectedBody);
+        }
+
+        outputSubscription.dispose();
+    });
 
     test('failed AppHost start writes error to debug console', async () => {
         const parentDebugSession = {

--- a/extension/src/test/rpc/interactionServiceTests.test.ts
+++ b/extension/src/test/rpc/interactionServiceTests.test.ts
@@ -238,28 +238,223 @@ suite('InteractionService endpoints', () => {
 	test("displayDashboardUrls writes URLs but does not show info message when autoLaunch is launch", async () => {
 		const stub = sinon.stub(extensionLogOutputChannel, 'info');
 		const showInformationMessageStub = sinon.stub(vscode.window, 'showInformationMessage').resolves();
+		const openExternalStub = sinon.stub(vscode.env, 'openExternal').resolves(true);
+		const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand').resolves(undefined);
 		const getConfigurationStub = sinon.stub(vscode.workspace, 'getConfiguration').returns({
 			get: (key: string, defaultValue?: any) => key === 'enableAspireDashboardAutoLaunch' ? 'launch' : defaultValue
 		} as any);
 		const testInfo = await createTestRpcServer();
 
-		const baseUrl = 'http://localhost';
-		const codespacesUrl = 'http://codespaces';
+		try {
+			const baseUrl = 'http://localhost';
+			const codespacesUrl = 'http://codespaces';
 
-		await testInfo.interactionService.displayDashboardUrls({
-			BaseUrlWithLoginToken: baseUrl,
-			CodespacesUrlWithLoginToken: codespacesUrl
-		});
+			await testInfo.interactionService.displayDashboardUrls({
+				BaseUrlWithLoginToken: baseUrl,
+				CodespacesUrlWithLoginToken: codespacesUrl
+			});
 
-		const outputLines = stub.getCalls().map(call => call.args[0]);
+			const outputLines = stub.getCalls().map(call => call.args[0]);
 
-		// No need to wait since no setTimeout should be called when autoLaunch is enabled
-		assert.ok(outputLines.some(line => line.includes(baseUrl)), 'Output should contain base URL');
-		assert.ok(outputLines.some(line => line.includes(codespacesUrl)), 'Output should contain codespaces URL');
-		assert.equal(showInformationMessageStub.callCount, 0, 'Should not show info message when autoLaunch is launch');
-		stub.restore();
-		showInformationMessageStub.restore();
-		getConfigurationStub.restore();
+			// No need to wait since no setTimeout should be called when autoLaunch is enabled
+			assert.ok(outputLines.some(line => line.includes(baseUrl)), 'Output should contain base URL');
+			assert.ok(outputLines.some(line => line.includes(codespacesUrl)), 'Output should contain codespaces URL');
+			assert.strictEqual(openExternalStub.callCount, 1, 'Should open the dashboard when autoLaunch is launch');
+			assert.strictEqual(openExternalStub.getCall(0).args[0].toString(true), vscode.Uri.parse(codespacesUrl).toString(true), 'Should prefer Codespaces URL when available');
+			assert.ok(executeCommandStub.calledWith('aspire-vscode.refreshRunningAppHosts'), 'Should refresh running AppHosts');
+			assert.equal(showInformationMessageStub.callCount, 0, 'Should not show info message when autoLaunch is launch');
+		}
+		finally {
+			stub.restore();
+			showInformationMessageStub.restore();
+			openExternalStub.restore();
+			executeCommandStub.restore();
+			getConfigurationStub.restore();
+		}
+	});
+
+	test("displayDashboardUrls opens dashboard through the Aspire debug session when one exists", async () => {
+		const stub = sinon.stub(extensionLogOutputChannel, 'info');
+		const showInformationMessageStub = sinon.stub(vscode.window, 'showInformationMessage').resolves();
+		const openExternalStub = sinon.stub(vscode.env, 'openExternal').resolves(true);
+		const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand').resolves(undefined);
+		const getConfigurationStub = sinon.stub(vscode.workspace, 'getConfiguration').returns({
+			get: (key: string, defaultValue?: any) => {
+				if (key === 'enableAspireDashboardAutoLaunch') {
+					return 'launch';
+				}
+				if (key === 'dashboardBrowser') {
+					return 'debugEdge';
+				}
+				return defaultValue;
+			}
+		} as any);
+		const mockDebugSession = {
+			sendMessage: sinon.stub(),
+			openDashboard: sinon.stub().resolves()
+		} as unknown as AspireDebugSession;
+		const testInfo = await createTestRpcServer(null, () => mockDebugSession);
+
+		try {
+			const baseUrl = 'http://localhost:15000/login?t=abc';
+			const codespacesUrl = 'http://codespaces/login?t=abc';
+
+			await testInfo.interactionService.displayDashboardUrls({
+				BaseUrlWithLoginToken: baseUrl,
+				CodespacesUrlWithLoginToken: codespacesUrl
+			});
+
+			assert.strictEqual((mockDebugSession.openDashboard as sinon.SinonStub).callCount, 1, 'Should ask the Aspire debug session to open the dashboard');
+			assert.deepStrictEqual((mockDebugSession.openDashboard as sinon.SinonStub).getCall(0).args, [codespacesUrl, 'debugEdge']);
+			assert.strictEqual(openExternalStub.callCount, 0, 'Should not bypass the Aspire debug session');
+			assert.ok(executeCommandStub.calledWith('aspire-vscode.refreshRunningAppHosts'), 'Should refresh running AppHosts');
+			assert.equal(showInformationMessageStub.callCount, 0, 'Should not show info message when autoLaunch is launch');
+		}
+		finally {
+			stub.restore();
+			showInformationMessageStub.restore();
+			openExternalStub.restore();
+			executeCommandStub.restore();
+			getConfigurationStub.restore();
+		}
+	});
+
+	test("displayDashboardUrls opens external browser when autoLaunch is launch without Aspire debug session", async () => {
+		const stub = sinon.stub(extensionLogOutputChannel, 'info');
+		const showInformationMessageStub = sinon.stub(vscode.window, 'showInformationMessage').resolves();
+		const asExternalUriStub = sinon.stub(vscode.env, 'asExternalUri').rejects(new Error('openExternal resolves external URIs'));
+		const openExternalStub = sinon.stub(vscode.env, 'openExternal').resolves(true);
+		const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand').resolves(undefined);
+		const getConfigurationStub = sinon.stub(vscode.workspace, 'getConfiguration').returns({
+			get: (key: string, defaultValue?: any) => {
+				if (key === 'enableAspireDashboardAutoLaunch') {
+					return 'launch';
+				}
+				if (key === 'dashboardBrowser') {
+					return 'openExternalBrowser';
+				}
+				return defaultValue;
+			}
+		} as any);
+		const testInfo = await createTestRpcServer(null, () => null);
+
+		try {
+			const baseUrl = 'http://localhost:15000/login?t=abc';
+
+			await testInfo.interactionService.displayDashboardUrls({
+				BaseUrlWithLoginToken: baseUrl,
+				CodespacesUrlWithLoginToken: null
+			});
+
+			assert.strictEqual(openExternalStub.callCount, 1, 'Should open external browser without an Aspire debug session');
+			assert.strictEqual(openExternalStub.getCall(0).args[0].toString(true), baseUrl);
+			assert.strictEqual(asExternalUriStub.callCount, 0, 'openExternal resolves remote dashboard URLs itself');
+			assert.ok(executeCommandStub.calledWith('aspire-vscode.refreshRunningAppHosts'), 'Should refresh running AppHosts');
+			assert.equal(showInformationMessageStub.callCount, 0, 'Should not show info message when autoLaunch is launch');
+		}
+		finally {
+			stub.restore();
+			showInformationMessageStub.restore();
+			asExternalUriStub.restore();
+			openExternalStub.restore();
+			executeCommandStub.restore();
+			getConfigurationStub.restore();
+		}
+	});
+
+	test("displayDashboardUrls opens integrated browser when autoLaunch is launch without Aspire debug session", async () => {
+		const stub = sinon.stub(extensionLogOutputChannel, 'info');
+		const showInformationMessageStub = sinon.stub(vscode.window, 'showInformationMessage').resolves();
+		const externalUrl = vscode.Uri.parse('http://127.0.0.1:55001/login?t=abc');
+		const asExternalUriStub = sinon.stub(vscode.env, 'asExternalUri').resolves(externalUrl);
+		const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand').resolves(undefined);
+		const getConfigurationStub = sinon.stub(vscode.workspace, 'getConfiguration').returns({
+			get: (key: string, defaultValue?: any) => {
+				if (key === 'enableAspireDashboardAutoLaunch') {
+					return 'launch';
+				}
+				if (key === 'dashboardBrowser') {
+					return 'integratedBrowser';
+				}
+				return defaultValue;
+			}
+		} as any);
+		const testInfo = await createTestRpcServer(null, () => null);
+
+		try {
+			const baseUrl = 'http://localhost:15000/login?t=abc';
+
+			await testInfo.interactionService.displayDashboardUrls({
+				BaseUrlWithLoginToken: baseUrl,
+				CodespacesUrlWithLoginToken: null
+			});
+
+			assert.strictEqual(asExternalUriStub.callCount, 1, 'Should resolve remote dashboard URL before opening');
+			assert.strictEqual(asExternalUriStub.getCall(0).args[0].toString(true), baseUrl);
+			assert.ok(executeCommandStub.calledWith('simpleBrowser.show', externalUrl.toString(true)), 'Should open integrated browser without an Aspire debug session');
+			assert.equal(showInformationMessageStub.callCount, 0, 'Should not show info message when autoLaunch is launch');
+		}
+		finally {
+			stub.restore();
+			showInformationMessageStub.restore();
+			asExternalUriStub.restore();
+			executeCommandStub.restore();
+			getConfigurationStub.restore();
+		}
+	});
+
+	test("displayDashboardUrls opens debug browser when autoLaunch is launch without Aspire debug session", async () => {
+		const stub = sinon.stub(extensionLogOutputChannel, 'info');
+		const showInformationMessageStub = sinon.stub(vscode.window, 'showInformationMessage').resolves();
+		const externalUrl = vscode.Uri.parse('http://127.0.0.1:55002/login?t=abc');
+		const asExternalUriStub = sinon.stub(vscode.env, 'asExternalUri').resolves(externalUrl);
+		const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand').resolves(undefined);
+		const startDebuggingStub = sinon.stub(vscode.debug, 'startDebugging').resolves(true);
+		const onDidStartDebugSessionStub = sinon.stub(vscode.debug, 'onDidStartDebugSession').returns({ dispose: () => { } });
+		const getConfigurationStub = sinon.stub(vscode.workspace, 'getConfiguration').returns({
+			get: (key: string, defaultValue?: any) => {
+				if (key === 'enableAspireDashboardAutoLaunch') {
+					return 'launch';
+				}
+				if (key === 'dashboardBrowser') {
+					return 'debugEdge';
+				}
+				return defaultValue;
+			}
+		} as any);
+		const testInfo = await createTestRpcServer(null, () => null);
+
+		try {
+			const baseUrl = 'http://localhost:15000/login?t=abc';
+
+			await testInfo.interactionService.displayDashboardUrls({
+				BaseUrlWithLoginToken: baseUrl,
+				CodespacesUrlWithLoginToken: null
+			});
+
+			assert.strictEqual(asExternalUriStub.callCount, 1, 'Should resolve remote dashboard URL before debugging browser');
+			assert.strictEqual(asExternalUriStub.getCall(0).args[0].toString(true), baseUrl);
+			assert.ok(executeCommandStub.calledWith('aspire-vscode.refreshRunningAppHosts'), 'Should refresh running AppHosts');
+			assert.strictEqual(startDebuggingStub.callCount, 1, 'Should start debug browser without an Aspire debug session');
+			assert.strictEqual(startDebuggingStub.getCall(0).args[2], undefined, 'Debug browser should not require an Aspire parent session');
+			assert.deepStrictEqual(startDebuggingStub.getCall(0).args[1], {
+				type: 'pwa-msedge',
+				name: 'Aspire Dashboard',
+				request: 'launch',
+				url: externalUrl.toString(true),
+				pauseForSourceMap: false
+			});
+			assert.equal(showInformationMessageStub.callCount, 0, 'Should not show info message when autoLaunch is launch');
+		}
+		finally {
+			stub.restore();
+			showInformationMessageStub.restore();
+			asExternalUriStub.restore();
+			executeCommandStub.restore();
+			startDebuggingStub.restore();
+			onDidStartDebugSessionStub.restore();
+			getConfigurationStub.restore();
+		}
 	});
 
 	test("displayLines endpoint", async () => {


### PR DESCRIPTION
## Description

Fixes microsoft/aspire#17176.

Dashboard auto-launch in VS Code Remote SSH could silently fail or become unstable depending on how the AppHost was launched. This change uses a shared dashboard browser launcher for both Aspire debug-session and non-Aspire-debug-session flows, resolves remote dashboard URLs for client-side browser surfaces, and fixes malformed empty DAP responses from the Aspire parent debug adapter.

### How I reproduced the original issue

Environment/setup from the report:

- Local VS Code client on Windows with Aspire extension 1.0.8 / Aspire 13.3.x behavior.
- VS Code Remote SSH connected to a remote macOS AppHost workspace.
- **Aspire: Enable Aspire Dashboard Auto Launch** set to `launch`.
- **Aspire: Dashboard Browser** tested with integrated browser, external browser, and debug browser modes.
- AppHost launch through **Aspire: Launch default AppHost** / F5; adjacent extension path also covers C# Dev Kit / `type: dotnet` AppHost launch.

Manual repro path:

1. Connect to the remote Aspire workspace through VS Code Remote SSH.
2. Set dashboard auto-launch to `launch` and choose a dashboard browser mode.
3. Start the AppHost with **Aspire: Launch default AppHost** / F5.
4. Before the fix, the dashboard browser can fail to launch in the selected browser mode, and the extension host can show `Cannot read properties of undefined (reading 'forEach')` from malformed Aspire debug-session DAP responses.
5. Repeat with a C# Dev Kit / `type: dotnet` launch configuration that starts the AppHost. Before the fix, the extension receives dashboard URLs, but auto-launch is skipped because there is no Aspire parent debug session.
6. In Remote SSH, integrated/debug browser launches also need remote `localhost` dashboard URLs resolved through VS Code before opening a client-side browser surface.

Automated repro used for the fix:

- InteractionService tests cover dashboard auto-launch when no Aspire debug session exists.
- AspireDebugSession tests cover the existing Aspire-debug-session path and DAP response body shapes for `variables`, `scopes`, `stackTrace`, and `threads`.
- Browser-launcher tests cover `vscode.env.asExternalUri(...)` resolution for integrated/debug browser modes.
- I did not have the reporter's live Windows-to-macOS Remote SSH environment in this worktree, so the local repro evidence is from the issue report plus targeted VS Code extension tests for the failing launch paths.

### Root cause analysis

Issue #17176 had two related VS Code launch paths.

1. When the AppHost is launched through C# Dev Kit / `type: dotnet`, the Aspire extension still receives the dashboard URLs from the CLI/RPC path, but there is no active `AspireDebugSession`. The auto-launch code only opened the dashboard through `_getAspireDebugSession()?.openDashboard(...)`, so the `launch` setting was silently skipped when that session was absent.

2. When the AppHost is launched with `Aspire: Launch default AppHost`, an Aspire debug session does exist. In that path the parent Aspire debug adapter is an orchestrator, but it still replied `success: true` with an empty `{}` body to normal DAP requests such as `variables`, `scopes`, `stackTrace`, and `threads`. VS Code expects collection responses to contain arrays like `body.variables`, so it could throw `TypeError: Cannot read properties of undefined (reading 'forEach')` during the Aspire debug session. That matches the reporter's extension host error and can destabilize the session before the dashboard browser launch runs correctly.

There was also a remote-host URL handling gap for the Aspire debug-session browser launch path: integrated and debug browser launches used the raw dashboard URL from the remote extension host. In Remote SSH, that can be a remote `localhost` address that must be converted with VS Code's external URI resolver before it is used by client-side browser surfaces.

### Why this fix

Dashboard auto-launch should happen whenever the extension receives dashboard URLs and the setting is `launch`, regardless of whether those URLs came through an Aspire parent debug session or another launch flow. The Aspire parent debug adapter also needs to return protocol-shaped empty responses for DAP requests it does not implement, instead of returning successful malformed responses.

### Fix details

- Added a shared dashboard browser launcher used by both `InteractionService` and `AspireDebugSession`.
- `displayDashboardUrls` now keeps using the active Aspire debug session when one exists, but falls back to the shared launcher when it does not.
- Integrated and debug browser modes now resolve dashboard URLs with `vscode.env.asExternalUri(...)` before opening them; external browser mode continues to call `vscode.env.openExternal(...)` directly because VS Code documents that `openExternal` resolves remote URIs itself.
- Debug browser launches still become child debug sessions when an Aspire debug session exists, preserving cleanup with the parent session.
- The Aspire parent debug adapter now returns DAP-shaped empty bodies for collection-style requests such as `variables`, `scopes`, `stackTrace`, and `threads` so VS Code does not try to enumerate undefined arrays.
- Added regression coverage for the no-Aspire-debug-session path, the existing-Aspire-debug-session path, remote URL resolution for debug browsers, and the DAP response body shapes.

### Validation

- `npm run compile-tests -- --pretty false`
- `npm run lint -- --quiet`
- `npm run compile -- --mode development` (webpack emits the existing optional dependency warnings for `bufferutil` / `utf-8-validate` and the Express dynamic require warning)
- `npx vscode-test --config <short-path test config> --grep 'InteractionService endpoints|Dotnet Debugger Extension Tests'` — 40 passing

### Manual testing

1. In a Remote SSH workspace with an Aspire AppHost, set `Aspire: Enable Aspire Dashboard Auto Launch` to `launch` and set `Aspire: Dashboard Browser` to each browser mode you want to verify.
2. Start `Aspire: Launch default AppHost` with F5.
3. Confirm the dashboard opens with the login-token URL, not a project site, and the VS Code developer tools console does not show `Cannot read properties of undefined (reading 'forEach')` from the Aspire debug session.
4. Repeat with a C# Dev Kit / `type: dotnet` launch configuration that points at the AppHost project and confirm dashboard auto-launch still happens even though there is no Aspire parent debug session.
5. Optionally switch auto-launch to `notification` and `off` to confirm those modes still show the notification or suppress launch respectively.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
